### PR TITLE
Add GitHub Actions CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,54 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build & Typecheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      - name: Build shared package
+        run: npx turbo build --filter=@mindscape/shared
+
+      - name: Build API
+        run: npx turbo build --filter=@mindscape/api
+
+      - name: Build Web
+        run: npx turbo build --filter=@mindscape/web
+
+  typecheck:
+    name: Typecheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      - name: Typecheck shared
+        run: npm run lint --workspace=@mindscape/shared
+
+      - name: Typecheck API
+        working-directory: apps/api
+        run: npx tsc --noEmit


### PR DESCRIPTION
## Summary
- Adds CI workflow that runs on every PR to `main` and push to `main`
- **Build job**: builds all 3 packages (shared, api, web) via Turborepo
- **Typecheck job**: runs `tsc --noEmit` on shared + API packages
- Concurrency control to cancel stale runs

## Test plan
- [ ] CI passes on this PR itself (self-validating)
- [ ] Verify build job completes for all 3 workspaces
- [ ] Verify typecheck job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)