### PR TITLE
Add Zustand stores and Socket.IO hooks for frontend

### DIFF
--- a/apps/web/src/hooks/useCanvas.ts
+++ b/apps/web/src/hooks/useCanvas.ts
@@ -1,0 +1,97 @@
+'use client';
+
+import { useEffect, useCallback, useMemo } from 'react';
+import { useShallow } from 'zustand/shallow';
+import type { CreateNodePayload, CanvasNode } from '@mindscape/shared';
+import { useSocket } from './useSocket';
+import { useCanvasStore } from '../stores/canvas-store';
+
+export function useCanvas(canvasId: string) {
+  const socket = useSocket();
+
+  const { nodes, edges, selectedIds, setNodes, setEdges, addNode, updateNode: storeUpdateNode, removeNode, setSelection } =
+    useCanvasStore(
+      useShallow((s) => ({
+        nodes: s.nodes,
+        edges: s.edges,
+        selectedIds: s.selectedIds,
+        setNodes: s.setNodes,
+        setEdges: s.setEdges,
+        addNode: s.addNode,
+        updateNode: s.updateNode,
+        removeNode: s.removeNode,
+        setSelection: s.setSelection,
+      })),
+    );
+
+  useEffect(() => {
+    socket.emit('join-canvas', { canvasId });
+
+    socket.on('canvas:state', ({ nodes: incomingNodes, edges: incomingEdges }) => {
+      setNodes(incomingNodes);
+      setEdges(incomingEdges);
+    });
+
+    socket.on('node:created', ({ node }) => {
+      addNode(node);
+    });
+
+    socket.on('node:updated', ({ id, patch }) => {
+      storeUpdateNode(id, patch);
+    });
+
+    socket.on('node:deleted', ({ id }) => {
+      removeNode(id);
+    });
+
+    return () => {
+      socket.emit('leave-canvas', { canvasId });
+      socket.off('canvas:state');
+      socket.off('node:created');
+      socket.off('node:updated');
+      socket.off('node:deleted');
+    };
+  }, [canvasId, socket, setNodes, setEdges, addNode, storeUpdateNode, removeNode]);
+
+  const createNode = useCallback(
+    (payload: CreateNodePayload) => {
+      socket.emit('node:create', { node: payload });
+    },
+    [socket],
+  );
+
+  const updateNode = useCallback(
+    (id: string, patch: Partial<CanvasNode>) => {
+      socket.emit('node:update', { id, patch });
+    },
+    [socket],
+  );
+
+  const deleteNode = useCallback(
+    (id: string) => {
+      socket.emit('node:delete', { id });
+    },
+    [socket],
+  );
+
+  const changeSelection = useCallback(
+    (ids: string[]) => {
+      setSelection(ids);
+      socket.emit('selection:change', { nodeIds: ids });
+    },
+    [socket, setSelection],
+  );
+
+  return useMemo(
+    () => ({
+      nodes,
+      edges,
+      selectedIds,
+      createNode,
+      updateNode,
+      deleteNode,
+      setSelection: changeSelection,
+    }),
+    [nodes, edges, selectedIds, createNode, updateNode, deleteNode, changeSelection],
+  );
+}

--- a/apps/web/src/hooks/useSocket.ts
+++ b/apps/web/src/hooks/useSocket.ts
@@ -1,0 +1,46 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { io, Socket } from 'socket.io-client';
+import type { ClientToServerEvents, ServerToClientEvents } from '@mindscape/shared';
+
+type TypedSocket = Socket<ServerToClientEvents, ClientToServerEvents>;
+
+const SOCKET_URL = process.env.NEXT_PUBLIC_WS_URL ?? 'http://localhost:4000';
+const NAMESPACE = '/canvas';
+
+let socket: TypedSocket | null = null;
+let refCount = 0;
+
+function getSocket(): TypedSocket {
+  if (!socket) {
+    socket = io(`${SOCKET_URL}${NAMESPACE}`, {
+      autoConnect: false,
+      transports: ['websocket'],
+    }) as TypedSocket;
+  }
+  return socket;
+}
+
+export function useSocket(): TypedSocket {
+  const socketRef = useRef<TypedSocket>(getSocket());
+
+  useEffect(() => {
+    const s = socketRef.current;
+    refCount++;
+    if (!s.connected) {
+      s.connect();
+    }
+
+    return () => {
+      refCount--;
+      if (refCount <= 0) {
+        s.disconnect();
+        socket = null;
+        refCount = 0;
+      }
+    };
+  }, []);
+
+  return socketRef.current;
+}

--- a/apps/web/src/hooks/useViewport.ts
+++ b/apps/web/src/hooks/useViewport.ts
@@ -1,0 +1,70 @@
+'use client';
+
+import { useCallback, useMemo } from 'react';
+import { useShallow } from 'zustand/shallow';
+import type Konva from 'konva';
+import type { Viewport } from '@mindscape/shared';
+import { useCanvasStore } from '../stores/canvas-store';
+
+const MIN_ZOOM = 0.1;
+const MAX_ZOOM = 5;
+const ZOOM_FACTOR = 1.08;
+
+function clampZoom(zoom: number): number {
+  return Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, zoom));
+}
+
+export function useViewport() {
+  const { viewport, updateViewport } = useCanvasStore(
+    useShallow((s) => ({
+      viewport: s.viewport,
+      updateViewport: s.updateViewport,
+    })),
+  );
+
+  const handleWheel = useCallback(
+    (e: Konva.KonvaEventObject<WheelEvent>) => {
+      e.evt.preventDefault();
+      const stage = e.target.getStage();
+      if (!stage) return;
+
+      const pointer = stage.getPointerPosition();
+      if (!pointer) return;
+
+      const direction = e.evt.deltaY > 0 ? -1 : 1;
+      const oldZoom = viewport.zoom;
+      const newZoom = clampZoom(direction > 0 ? oldZoom * ZOOM_FACTOR : oldZoom / ZOOM_FACTOR);
+
+      const mousePointTo = {
+        x: (pointer.x - viewport.x) / oldZoom,
+        y: (pointer.y - viewport.y) / oldZoom,
+      };
+
+      updateViewport({
+        x: pointer.x - mousePointTo.x * newZoom,
+        y: pointer.y - mousePointTo.y * newZoom,
+        zoom: newZoom,
+      });
+    },
+    [viewport, updateViewport],
+  );
+
+  const handleDragEnd = useCallback(
+    (e: Konva.KonvaEventObject<DragEvent>) => {
+      updateViewport({
+        x: e.target.x(),
+        y: e.target.y(),
+      });
+    },
+    [updateViewport],
+  );
+
+  return useMemo(
+    () => ({
+      viewport,
+      handleWheel,
+      handleDragEnd,
+    }),
+    [viewport, handleWheel, handleDragEnd],
+  );
+}

--- a/apps/web/src/stores/agent-store.ts
+++ b/apps/web/src/stores/agent-store.ts
@@ -1,0 +1,50 @@
+import { create } from 'zustand';
+import type { AgentSession } from '@mindscape/shared';
+
+interface AgentState {
+  sessions: Map<string, AgentSession>;
+  activeSessionId: string | null;
+}
+
+interface AgentActions {
+  addSession: (session: AgentSession) => void;
+  updateSession: (id: string, patch: Partial<AgentSession>) => void;
+  removeSession: (id: string) => void;
+  setActiveSession: (id: string | null) => void;
+}
+
+export type AgentStore = AgentState & AgentActions;
+
+export const useAgentStore = create<AgentStore>()((set) => ({
+  sessions: new Map(),
+  activeSessionId: null,
+
+  addSession: (session) =>
+    set((state) => {
+      const sessions = new Map(state.sessions);
+      sessions.set(session.id, session);
+      return { sessions };
+    }),
+
+  updateSession: (id, patch) =>
+    set((state) => {
+      const existing = state.sessions.get(id);
+      if (!existing) return state;
+      const sessions = new Map(state.sessions);
+      sessions.set(id, { ...existing, ...patch });
+      return { sessions };
+    }),
+
+  removeSession: (id) =>
+    set((state) => {
+      const sessions = new Map(state.sessions);
+      sessions.delete(id);
+      const activeSessionId = state.activeSessionId === id ? null : state.activeSessionId;
+      return { sessions, activeSessionId };
+    }),
+
+  setActiveSession: (id) =>
+    set(() => ({
+      activeSessionId: id,
+    })),
+}));

--- a/apps/web/src/stores/canvas-store.ts
+++ b/apps/web/src/stores/canvas-store.ts
@@ -1,0 +1,89 @@
+import { create } from 'zustand';
+import type { CanvasNode, Edge, Viewport } from '@mindscape/shared';
+
+interface CanvasState {
+  nodes: Map<string, CanvasNode>;
+  edges: Map<string, Edge>;
+  selectedIds: Set<string>;
+  viewport: Viewport;
+}
+
+interface CanvasActions {
+  addNode: (node: CanvasNode) => void;
+  updateNode: (id: string, patch: Partial<CanvasNode>) => void;
+  removeNode: (id: string) => void;
+  addEdge: (edge: Edge) => void;
+  removeEdge: (id: string) => void;
+  setNodes: (nodes: CanvasNode[]) => void;
+  setEdges: (edges: Edge[]) => void;
+  setSelection: (ids: string[]) => void;
+  updateViewport: (viewport: Partial<Viewport>) => void;
+}
+
+export type CanvasStore = CanvasState & CanvasActions;
+
+export const useCanvasStore = create<CanvasStore>()((set) => ({
+  nodes: new Map(),
+  edges: new Map(),
+  selectedIds: new Set(),
+  viewport: { x: 0, y: 0, zoom: 1 },
+
+  addNode: (node) =>
+    set((state) => {
+      const nodes = new Map(state.nodes);
+      nodes.set(node.id, node);
+      return { nodes };
+    }),
+
+  updateNode: (id, patch) =>
+    set((state) => {
+      const existing = state.nodes.get(id);
+      if (!existing) return state;
+      const nodes = new Map(state.nodes);
+      nodes.set(id, { ...existing, ...patch });
+      return { nodes };
+    }),
+
+  removeNode: (id) =>
+    set((state) => {
+      const nodes = new Map(state.nodes);
+      nodes.delete(id);
+      const selectedIds = new Set(state.selectedIds);
+      selectedIds.delete(id);
+      return { nodes, selectedIds };
+    }),
+
+  addEdge: (edge) =>
+    set((state) => {
+      const edges = new Map(state.edges);
+      edges.set(edge.id, edge);
+      return { edges };
+    }),
+
+  removeEdge: (id) =>
+    set((state) => {
+      const edges = new Map(state.edges);
+      edges.delete(id);
+      return { edges };
+    }),
+
+  setNodes: (nodes) =>
+    set(() => ({
+      nodes: new Map(nodes.map((n) => [n.id, n])),
+    })),
+
+  setEdges: (edges) =>
+    set(() => ({
+      edges: new Map(edges.map((e) => [e.id, e])),
+    })),
+
+  setSelection: (ids) =>
+    set(() => ({
+      selectedIds: new Set(ids),
+    })),
+
+  updateViewport: (patch) =>
+    set((state) => ({
+      viewport: { ...state.viewport, ...patch },
+    })),
+}));


### PR DESCRIPTION
## Summary
- **Canvas store** (`canvas-store.ts`): Zustand v5 store managing `nodes`, `edges`, `selectedIds`, and `viewport` state with immutable Map/Set updates
- **Agent store** (`agent-store.ts`): Zustand v5 store for AI agent sessions with add/update/remove/setActive actions
- **useSocket hook**: Singleton Socket.IO connection to `/canvas` namespace with ref-counted connect/disconnect lifecycle and full `ClientToServerEvents`/`ServerToClientEvents` type safety
- **useCanvas hook**: Joins/leaves canvas rooms, syncs server events (`canvas:state`, `node:created`, `node:updated`, `node:deleted`) to the store, and exposes `createNode`, `updateNode`, `deleteNode`, `setSelection` emitters
- **useViewport hook**: Wheel zoom (clamped 0.1x-5x) and drag pan handlers for Konva Stage integration, backed by the canvas store viewport state

## Test plan
- [ ] Verify `npx turbo build --filter=@mindscape/web` passes (confirmed locally)
- [ ] Smoke test: mount `useCanvas("test-id")` in a component, verify socket connects and emits `join-canvas`
- [ ] Verify `useViewport` wheel zoom stays within 0.1-5x bounds
- [ ] Verify `useSocket` singleton behavior: multiple hook consumers share one connection
- [ ] Verify store immutability: `addNode`/`removeNode` produce new Map instances

🤖 Generated with [Claude Code](https://claude.com/claude-code)