### PR TITLE
Add AI agent runner with OpenRouter LLM integration

### DIFF
--- a/apps/api/src/agent/agent-runner.controller.ts
+++ b/apps/api/src/agent/agent-runner.controller.ts
@@ -1,0 +1,39 @@
+import { Controller, Post, Get, Param, Body } from '@nestjs/common';
+import { AgentRunnerService } from './agent-runner.service';
+import { AgentSessionRepository } from './agent-session.repository';
+import type { AgentInvokePayload } from '@mindscape/shared';
+
+/**
+ * REST endpoints for invoking and querying AI agents on a canvas.
+ *
+ * Agents run in the background — the POST returns immediately with a
+ * session ID. Progress is streamed to viewers via WebSocket.
+ */
+@Controller('canvases/:canvasId/agent')
+export class AgentRunnerController {
+  constructor(
+    private readonly runner: AgentRunnerService,
+    private readonly sessions: AgentSessionRepository,
+  ) {}
+
+  /** Invoke an agent on this canvas */
+  @Post('invoke')
+  invoke(
+    @Param('canvasId') canvasId: string,
+    @Body() body: AgentInvokePayload,
+  ) {
+    return this.runner.invoke(canvasId, body);
+  }
+
+  /** List all agent sessions for a canvas */
+  @Get('sessions')
+  listSessions(@Param('canvasId') canvasId: string) {
+    return this.sessions.findByCanvas(canvasId);
+  }
+
+  /** Get a specific agent session */
+  @Get('sessions/:sessionId')
+  getSession(@Param('sessionId') sessionId: string) {
+    return this.sessions.findById(sessionId);
+  }
+}

--- a/apps/api/src/agent/agent-runner.service.ts
+++ b/apps/api/src/agent/agent-runner.service.ts
@@ -1,0 +1,291 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { NodesService } from '../nodes/nodes.service';
+import { CanvasService } from '../canvas/canvas.service';
+import { AgentBroadcastService } from '../collaboration/agent-broadcast.service';
+import { AgentSessionRepository } from './agent-session.repository';
+import { toolsToOpenRouterFormat } from './agent-tools';
+import type { AgentInvokePayload, NodePayload } from '@mindscape/shared';
+
+interface LLMMessage {
+  role: 'system' | 'user' | 'assistant' | 'tool';
+  content: string | null;
+  tool_calls?: LLMToolCall[];
+  tool_call_id?: string;
+}
+
+interface LLMToolCall {
+  id: string;
+  type: 'function';
+  function: { name: string; arguments: string };
+}
+
+interface LLMResponse {
+  choices: Array<{
+    message: {
+      role: string;
+      content: string | null;
+      tool_calls?: LLMToolCall[];
+    };
+    finish_reason: string;
+  }>;
+}
+
+const SYSTEM_PROMPT = `You are an AI agent working on a collaborative infinite canvas called Mindscape.
+You can create, update, and delete nodes on the canvas using the provided tools.
+
+When creating nodes, space them out nicely (at least 250px apart) and use appropriate types:
+- sticky_note: for short ideas, reminders, brainstorming items
+- text_block: for longer explanations or documentation
+- code_block: for code snippets (set content.language)
+- ai_response: for your own analysis or responses
+- shape: for visual elements
+
+Always provide meaningful text content. Be creative and helpful.
+Think step-by-step: first understand the user's request, then plan what nodes to create, then execute.`;
+
+const MAX_TOOL_ROUNDS = 10;
+
+/**
+ * Executes an AI agent on a canvas.
+ *
+ * Flow: receive prompt → call LLM → execute tool calls → broadcast to viewers → repeat until done.
+ */
+@Injectable()
+export class AgentRunnerService {
+  private readonly logger = new Logger(AgentRunnerService.name);
+  private readonly apiKey: string;
+  private readonly apiUrl: string;
+
+  constructor(
+    private readonly configService: ConfigService,
+    private readonly nodesService: NodesService,
+    private readonly canvasService: CanvasService,
+    private readonly broadcast: AgentBroadcastService,
+    private readonly sessions: AgentSessionRepository,
+  ) {
+    this.apiKey = this.configService.get<string>('OPENROUTER_API_KEY', '');
+    this.apiUrl = this.configService.get<string>(
+      'OPENROUTER_API_URL',
+      'https://openrouter.ai/api/v1/chat/completions',
+    );
+  }
+
+  /**
+   * Invoke an agent on a canvas. Runs in the background (fire-and-forget).
+   * Progress is streamed to viewers via AgentBroadcastService.
+   */
+  async invoke(canvasId: string, payload: AgentInvokePayload): Promise<{ sessionId: string }> {
+    const model = payload.model || 'anthropic/claude-sonnet-4';
+
+    // 1. Create session
+    const session = await this.sessions.create(canvasId, 'canvas-agent', model);
+    this.broadcast.broadcastAgentStatus(canvasId, session.id, 'thinking');
+    this.logger.log(`Agent session ${session.id} started on canvas ${canvasId}`);
+
+    // 2. Run agent loop in background (don't await)
+    this.runAgentLoop(canvasId, session.id, model, payload).catch((err) => {
+      this.logger.error(`Agent session ${session.id} failed: ${err.message}`);
+      this.sessions.updateStatus(session.id, 'error');
+      this.broadcast.broadcastAgentError(canvasId, session.id, err.message);
+    });
+
+    return { sessionId: session.id };
+  }
+
+  private async runAgentLoop(
+    canvasId: string,
+    sessionId: string,
+    model: string,
+    payload: AgentInvokePayload,
+  ) {
+    // Build initial context with existing canvas nodes
+    const canvas = await this.canvasService.findOneWithNodes(canvasId);
+    const existingNodes = (canvas.nodes as Record<string, unknown>[]).map((n) => ({
+      id: n.id,
+      type: n.type,
+      positionX: n.position_x,
+      positionY: n.position_y,
+      width: n.width,
+      height: n.height,
+      content: n.content,
+    }));
+
+    const messages: LLMMessage[] = [
+      { role: 'system', content: SYSTEM_PROMPT },
+      {
+        role: 'user',
+        content: `Canvas currently has ${existingNodes.length} nodes:\n${JSON.stringify(existingNodes, null, 2)}\n\nUser request: ${payload.prompt}`,
+      },
+    ];
+
+    const tools = toolsToOpenRouterFormat();
+
+    // Agent loop: call LLM → execute tools → repeat
+    for (let round = 0; round < MAX_TOOL_ROUNDS; round++) {
+      this.broadcast.broadcastAgentStatus(canvasId, sessionId, 'thinking');
+
+      const response = await this.callLLM(model, messages, tools);
+      const choice = response.choices[0];
+
+      if (!choice) {
+        this.logger.warn(`No choice returned from LLM in round ${round}`);
+        break;
+      }
+
+      const assistantMsg = choice.message;
+
+      // If the LLM returned a text thought, broadcast it
+      if (assistantMsg.content) {
+        this.broadcast.broadcastAgentThought(canvasId, sessionId, assistantMsg.content);
+      }
+
+      // No tool calls → agent is done
+      if (!assistantMsg.tool_calls?.length) {
+        messages.push({ role: 'assistant', content: assistantMsg.content });
+        break;
+      }
+
+      // Append assistant message with tool calls
+      messages.push({
+        role: 'assistant',
+        content: assistantMsg.content,
+        tool_calls: assistantMsg.tool_calls,
+      });
+
+      // Execute each tool call
+      this.broadcast.broadcastAgentStatus(canvasId, sessionId, 'acting');
+
+      for (const toolCall of assistantMsg.tool_calls) {
+        const { name, arguments: argsStr } = toolCall.function;
+        let args: Record<string, unknown>;
+
+        try {
+          args = JSON.parse(argsStr);
+        } catch {
+          const errorMsg = `Invalid JSON arguments for tool ${name}`;
+          messages.push({ role: 'tool', content: errorMsg, tool_call_id: toolCall.id });
+          continue;
+        }
+
+        const result = await this.executeTool(canvasId, sessionId, name, args);
+
+        // Record tool call in DB
+        await this.sessions.appendToolCall(sessionId, { tool: name, args, result });
+
+        // Broadcast tool call to viewers
+        this.broadcast.broadcastAgentToolCall(canvasId, sessionId, name, args, result);
+
+        // Append tool result for next LLM round
+        messages.push({
+          role: 'tool',
+          content: JSON.stringify(result),
+          tool_call_id: toolCall.id,
+        });
+      }
+    }
+
+    // Done
+    await this.sessions.updateStatus(sessionId, 'idle');
+    this.broadcast.broadcastAgentStatus(canvasId, sessionId, 'idle');
+    this.logger.log(`Agent session ${sessionId} completed`);
+  }
+
+  private async executeTool(
+    canvasId: string,
+    sessionId: string,
+    toolName: string,
+    args: Record<string, unknown>,
+  ): Promise<unknown> {
+    try {
+      switch (toolName) {
+        case 'create_node': {
+          const node = await this.nodesService.create(canvasId, {
+            type: (args.type as string) ?? 'sticky_note',
+            positionX: args.positionX as number | undefined,
+            positionY: args.positionY as number | undefined,
+            width: args.width as number | undefined,
+            height: args.height as number | undefined,
+            content: args.content as Record<string, unknown> | undefined,
+            style: args.style as Record<string, unknown> | undefined,
+            createdBy: sessionId,
+          });
+          this.broadcast.broadcastNodeCreated(canvasId, this.toNodePayload(node));
+          return { success: true, nodeId: node.id };
+        }
+
+        case 'update_node': {
+          const id = args.id as string;
+          const patch = { ...args };
+          delete patch.id;
+          const updated = await this.nodesService.update(id, patch);
+          this.broadcast.broadcastNodeUpdated(canvasId, id, patch as Partial<NodePayload>);
+          return { success: true, nodeId: updated.id };
+        }
+
+        case 'delete_node': {
+          const id = args.id as string;
+          await this.nodesService.remove(id);
+          this.broadcast.broadcastNodeDeleted(canvasId, id);
+          return { success: true, deleted: id };
+        }
+
+        default:
+          return { error: `Unknown tool: ${toolName}` };
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.logger.warn(`Tool ${toolName} failed: ${message}`);
+      return { error: message };
+    }
+  }
+
+  private async callLLM(
+    model: string,
+    messages: LLMMessage[],
+    tools: ReturnType<typeof toolsToOpenRouterFormat>,
+  ): Promise<LLMResponse> {
+    const response = await fetch(this.apiUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${this.apiKey}`,
+      },
+      body: JSON.stringify({
+        model,
+        messages,
+        tools,
+        tool_choice: 'auto',
+        max_tokens: 4096,
+      }),
+    });
+
+    if (!response.ok) {
+      const body = await response.text();
+      throw new Error(`OpenRouter API error ${response.status}: ${body}`);
+    }
+
+    return response.json() as Promise<LLMResponse>;
+  }
+
+  /** Map raw DB row (snake_case) to NodePayload (camelCase) */
+  private toNodePayload(row: Record<string, unknown>): NodePayload {
+    return {
+      id: row.id as string,
+      canvasId: row.canvas_id as string,
+      type: row.type as NodePayload['type'],
+      positionX: row.position_x as number,
+      positionY: row.position_y as number,
+      width: row.width as number,
+      height: row.height as number,
+      rotation: (row.rotation as number) ?? 0,
+      zIndex: row.z_index as number,
+      content: row.content as Record<string, unknown>,
+      style: row.style as Record<string, unknown>,
+      locked: (row.locked as boolean) ?? false,
+      createdBy: (row.created_by as string) ?? null,
+      createdAt: row.created_at as string,
+      updatedAt: row.updated_at as string,
+    };
+  }
+}

--- a/apps/api/src/agent/agent-session.repository.ts
+++ b/apps/api/src/agent/agent-session.repository.ts
@@ -1,0 +1,64 @@
+import { Injectable, Inject } from '@nestjs/common';
+import { Pool } from 'pg';
+import { PG_POOL } from '../database/database.provider';
+import type { AgentStatus } from '@mindscape/shared';
+
+export interface AgentSessionRow {
+  id: string;
+  canvas_id: string;
+  agent_name: string;
+  model: string;
+  status: AgentStatus;
+  context: Record<string, unknown>;
+  tool_calls: unknown[];
+  created_at: string;
+  updated_at: string;
+}
+
+@Injectable()
+export class AgentSessionRepository {
+  constructor(@Inject(PG_POOL) private readonly pg: Pool) {}
+
+  async create(canvasId: string, agentName: string, model: string): Promise<AgentSessionRow> {
+    const { rows } = await this.pg.query<AgentSessionRow>(
+      `INSERT INTO agent_sessions (canvas_id, agent_name, model, status)
+       VALUES ($1, $2, $3, 'thinking')
+       RETURNING *`,
+      [canvasId, agentName, model],
+    );
+    return rows[0];
+  }
+
+  async updateStatus(id: string, status: AgentStatus): Promise<void> {
+    await this.pg.query(
+      `UPDATE agent_sessions SET status = $1, updated_at = NOW() WHERE id = $2`,
+      [status, id],
+    );
+  }
+
+  async appendToolCall(id: string, toolCall: { tool: string; args: unknown; result: unknown }): Promise<void> {
+    await this.pg.query(
+      `UPDATE agent_sessions
+       SET tool_calls = tool_calls || $1::jsonb,
+           updated_at = NOW()
+       WHERE id = $2`,
+      [JSON.stringify([{ ...toolCall, timestamp: new Date().toISOString() }]), id],
+    );
+  }
+
+  async findById(id: string): Promise<AgentSessionRow | null> {
+    const { rows } = await this.pg.query<AgentSessionRow>(
+      `SELECT * FROM agent_sessions WHERE id = $1`,
+      [id],
+    );
+    return rows[0] ?? null;
+  }
+
+  async findByCanvas(canvasId: string): Promise<AgentSessionRow[]> {
+    const { rows } = await this.pg.query<AgentSessionRow>(
+      `SELECT * FROM agent_sessions WHERE canvas_id = $1 ORDER BY created_at DESC`,
+      [canvasId],
+    );
+    return rows;
+  }
+}

--- a/apps/api/src/agent/agent-tools.ts
+++ b/apps/api/src/agent/agent-tools.ts
@@ -1,0 +1,97 @@
+/**
+ * Tool definitions the LLM can call to manipulate the canvas.
+ *
+ * Each tool maps to a NodesService / CanvasService method.
+ * The agent runner parses the LLM response and dispatches to
+ * the appropriate service + broadcasts the result to viewers.
+ */
+
+export interface ToolDefinition {
+  name: string;
+  description: string;
+  parameters: Record<string, unknown>;
+}
+
+export const CANVAS_TOOLS: ToolDefinition[] = [
+  {
+    name: 'create_node',
+    description:
+      'Create a new node on the canvas. Use this to add sticky notes, text blocks, code blocks, AI responses, or shapes.',
+    parameters: {
+      type: 'object',
+      required: ['type'],
+      properties: {
+        type: {
+          type: 'string',
+          enum: ['sticky_note', 'text_block', 'code_block', 'ai_response', 'shape'],
+          description: 'The type of node to create',
+        },
+        positionX: { type: 'number', description: 'X position on the canvas (default: 0)' },
+        positionY: { type: 'number', description: 'Y position on the canvas (default: 0)' },
+        width: { type: 'number', description: 'Width in pixels (default: 200)' },
+        height: { type: 'number', description: 'Height in pixels (default: 200)' },
+        content: {
+          type: 'object',
+          description: 'Node content. Use { "text": "..." } for most node types.',
+          properties: {
+            text: { type: 'string', description: 'The text content of the node' },
+            title: { type: 'string', description: 'An optional title' },
+            language: { type: 'string', description: 'Programming language (for code_block)' },
+          },
+        },
+        style: {
+          type: 'object',
+          description: 'Visual style overrides',
+          properties: {
+            backgroundColor: { type: 'string' },
+            borderColor: { type: 'string' },
+            fontSize: { type: 'number' },
+          },
+        },
+      },
+    },
+  },
+  {
+    name: 'update_node',
+    description: 'Update an existing node on the canvas (change its content, position, size, or style).',
+    parameters: {
+      type: 'object',
+      required: ['id'],
+      properties: {
+        id: { type: 'string', description: 'The UUID of the node to update' },
+        positionX: { type: 'number' },
+        positionY: { type: 'number' },
+        width: { type: 'number' },
+        height: { type: 'number' },
+        content: { type: 'object' },
+        style: { type: 'object' },
+      },
+    },
+  },
+  {
+    name: 'delete_node',
+    description: 'Remove a node from the canvas.',
+    parameters: {
+      type: 'object',
+      required: ['id'],
+      properties: {
+        id: { type: 'string', description: 'The UUID of the node to delete' },
+      },
+    },
+  },
+];
+
+/**
+ * Convert our tool definitions into the OpenRouter / OpenAI
+ * function-calling format.
+ */
+export function toolsToOpenRouterFormat() {
+  return CANVAS_TOOLS.map((t) => ({
+    type: 'function' as const,
+    function: {
+      name: t.name,
+      description: t.description,
+      parameters: t.parameters,
+    },
+  }));
+}

--- a/apps/api/src/agent/agent.module.ts
+++ b/apps/api/src/agent/agent.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+import { CanvasModule } from '../canvas/canvas.module';
+import { NodesModule } from '../nodes/nodes.module';
+import { CollaborationModule } from '../collaboration/collaboration.module';
+import { AgentRunnerController } from './agent-runner.controller';
+import { AgentRunnerService } from './agent-runner.service';
+import { AgentSessionRepository } from './agent-session.repository';
+
+@Module({
+  imports: [CanvasModule, NodesModule, CollaborationModule],
+  controllers: [AgentRunnerController],
+  providers: [AgentRunnerService, AgentSessionRepository],
+  exports: [AgentRunnerService],
+})
+export class AgentModule {}

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -5,6 +5,7 @@ import { RedisModule } from './redis/redis.module';
 import { CanvasModule } from './canvas/canvas.module';
 import { NodesModule } from './nodes/nodes.module';
 import { CollaborationModule } from './collaboration/collaboration.module';
+import { AgentModule } from './agent/agent.module';
 
 @Module({
   imports: [
@@ -14,6 +15,7 @@ import { CollaborationModule } from './collaboration/collaboration.module';
     CanvasModule,
     NodesModule,
     CollaborationModule,
+    AgentModule,
   ],
 })
 export class AppModule {}


### PR DESCRIPTION
## Summary
- **AgentRunnerService**: LLM-powered agent loop that receives a prompt, calls OpenRouter, executes tool calls (create/update/delete nodes), and broadcasts every mutation to connected viewers in real-time
- **AgentSessionRepository**: persists agent sessions + tool call history to PostgreSQL `agent_sessions` table
- **AgentRunnerController**: REST endpoints — `POST /canvases/:id/agent/invoke`, `GET /canvases/:id/agent/sessions`
- **Canvas tool definitions**: `create_node`, `update_node`, `delete_node` in OpenAI function-calling format

## Architecture
```
POST /agent/invoke
  → AgentRunnerService.invoke()
    → Create session in DB
    → LLM loop (up to 10 rounds):
        → Call OpenRouter API
        → Parse tool calls
        → Execute via NodesService (DB write)
        → Broadcast via AgentBroadcastService (WebSocket → viewers)
    → Mark session idle
```

## Test plan
- [ ] `npx turbo build` passes (verified ✅)
- [ ] POST to `/canvases/:id/agent/invoke` with `{ "prompt": "Create 3 sticky notes" }` creates a session
- [ ] Connected viewers receive `agent:status`, `agent:thought`, `node:created` events in real-time
- [ ] GET `/canvases/:id/agent/sessions` returns session history with tool calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)