### PR TITLE
Add canvas creation route and window resize handling

### DIFF
--- a/apps/web/src/app/canvas/new/route.ts
+++ b/apps/web/src/app/canvas/new/route.ts
@@ -1,0 +1,23 @@
+import { redirect } from 'next/navigation';
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:4000';
+
+/**
+ * Server-side route that creates a new canvas and redirects to it.
+ * This is the only "write" the frontend makes — creating an empty
+ * canvas container. All content mutations come from backend agents.
+ */
+export async function GET() {
+  const res = await fetch(`${API_URL}/canvases`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ title: 'Untitled Canvas' }),
+  });
+
+  if (!res.ok) {
+    return new Response('Failed to create canvas', { status: 500 });
+  }
+
+  const canvas = (await res.json()) as { id: string };
+  redirect(`/canvas/${canvas.id}`);
+}

--- a/apps/web/src/components/canvas/InfiniteCanvas.tsx
+++ b/apps/web/src/components/canvas/InfiniteCanvas.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useRef, useCallback, useMemo } from 'react';
+import { useRef, useCallback, useMemo, useState, useEffect } from 'react';
 import { Stage, Layer, Rect, Text, Group, Circle, Line } from 'react-konva';
 import type Konva from 'konva';
 import { useCanvasStore } from '@/stores/canvas-store';
@@ -110,6 +110,16 @@ export default function InfiniteCanvas({ canvasId }: { canvasId: string }) {
   const nodeArray = useMemo(() => Array.from(nodes.values()), [nodes]);
   const edgeArray = useMemo(() => Array.from(edges.values()), [edges]);
 
+  /* ── window resize ────────────────────────────── */
+  const [stageSize, setStageSize] = useState({ width: 1200, height: 800 });
+
+  useEffect(() => {
+    const updateSize = () => setStageSize({ width: window.innerWidth, height: window.innerHeight });
+    updateSize();
+    window.addEventListener('resize', updateSize);
+    return () => window.removeEventListener('resize', updateSize);
+  }, []);
+
   /* ── zoom ──────────────────────────────────────── */
   const handleWheel = useCallback(
     (e: Konva.KonvaEventObject<WheelEvent>) => {
@@ -197,8 +207,8 @@ export default function InfiniteCanvas({ canvasId }: { canvasId: string }) {
       {/* ── Konva stage ─────────────────────────── */}
       <Stage
         ref={stageRef}
-        width={typeof window !== 'undefined' ? window.innerWidth : 1200}
-        height={typeof window !== 'undefined' ? window.innerHeight : 800}
+        width={stageSize.width}
+        height={stageSize.height}
         x={viewport.x}
         y={viewport.y}
         scaleX={viewport.zoom}


### PR DESCRIPTION
## Summary
- **`/canvas/new` server route**: creates a blank canvas via the API and redirects the viewer to `/canvas/:id` — this is the only write the frontend makes (creating an empty container, not canvas content)
- **Window resize handling**: `InfiniteCanvas` now properly tracks window size via React state instead of inline `window.innerWidth`, so the Konva stage resizes on browser resize

## Test plan
- [ ] `npx turbo build` passes (verified ✅)
- [ ] Clicking "Create Canvas" on home page → creates canvas → redirects to `/canvas/:id`
- [ ] Resizing browser window properly resizes the canvas stage

🤖 Generated with [Claude Code](https://claude.com/claude-code)