### PR TITLE
Fix WebSocket port mismatch and add missing env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,3 +16,6 @@ NEXTAUTH_URL=http://localhost:3000
 API_PORT=4000
 WEB_PORT=3000
 WS_CORS_ORIGIN=http://localhost:3000
+
+NEXT_PUBLIC_API_URL=http://localhost:4000
+NEXT_PUBLIC_WS_URL=http://localhost:4000

--- a/apps/web/src/hooks/use-canvas-socket.ts
+++ b/apps/web/src/hooks/use-canvas-socket.ts
@@ -7,7 +7,7 @@ import { useCanvasStore } from '@/stores/canvas-store';
 
 type TypedSocket = Socket<ServerToClientEvents, ClientToServerEvents>;
 
-const WS_URL = process.env.NEXT_PUBLIC_WS_URL ?? 'http://localhost:3001';
+const WS_URL = process.env.NEXT_PUBLIC_WS_URL ?? 'http://localhost:4000';
 
 /**
  * Hook that connects to the canvas WebSocket namespace and feeds


### PR DESCRIPTION
## Summary
- **Port fix**: Socket.IO hook defaulted to port 3001, should be 4000 (NestJS serves WS on same port as REST)
- **Env vars**: added `NEXT_PUBLIC_API_URL` and `NEXT_PUBLIC_WS_URL` to `.env.example`

Pre-launch fix to unblock end-to-end testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)