### PR TITLE
Add edge tools and improve agent spatial awareness

### DIFF
--- a/apps/api/src/agent/agent-tools.ts
+++ b/apps/api/src/agent/agent-tools.ts
@@ -79,6 +79,40 @@ export const CANVAS_TOOLS: ToolDefinition[] = [
       },
     },
   },
+  {
+    name: 'create_edge',
+    description:
+      'Create a directed edge (connection) between two nodes. Use this to show relationships, flow, or dependencies between ideas.',
+    parameters: {
+      type: 'object',
+      required: ['sourceId', 'targetId'],
+      properties: {
+        sourceId: { type: 'string', description: 'UUID of the source node' },
+        targetId: { type: 'string', description: 'UUID of the target node' },
+        label: { type: 'string', description: 'Optional label for the edge (e.g. "leads to", "depends on")' },
+        style: {
+          type: 'object',
+          description: 'Visual style overrides for the edge',
+          properties: {
+            color: { type: 'string' },
+            strokeWidth: { type: 'number' },
+            dashed: { type: 'boolean' },
+          },
+        },
+      },
+    },
+  },
+  {
+    name: 'delete_edge',
+    description: 'Remove an edge (connection) from the canvas.',
+    parameters: {
+      type: 'object',
+      required: ['id'],
+      properties: {
+        id: { type: 'string', description: 'The UUID of the edge to delete' },
+      },
+    },
+  },
 ];
 
 /**

--- a/apps/api/src/agent/agent.module.ts
+++ b/apps/api/src/agent/agent.module.ts
@@ -1,13 +1,14 @@
 import { Module } from '@nestjs/common';
 import { CanvasModule } from '../canvas/canvas.module';
 import { NodesModule } from '../nodes/nodes.module';
+import { EdgesModule } from '../edges/edges.module';
 import { CollaborationModule } from '../collaboration/collaboration.module';
 import { AgentRunnerController } from './agent-runner.controller';
 import { AgentRunnerService } from './agent-runner.service';
 import { AgentSessionRepository } from './agent-session.repository';
 
 @Module({
-  imports: [CanvasModule, NodesModule, CollaborationModule],
+  imports: [CanvasModule, NodesModule, EdgesModule, CollaborationModule],
   controllers: [AgentRunnerController],
   providers: [AgentRunnerService, AgentSessionRepository],
   exports: [AgentRunnerService],

--- a/apps/api/src/edges/edges.module.ts
+++ b/apps/api/src/edges/edges.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { EdgesService } from './edges.service';
+import { DatabaseModule } from '../database/database.module';
+
+@Module({
+  imports: [DatabaseModule],
+  providers: [EdgesService],
+  exports: [EdgesService],
+})
+export class EdgesModule {}

--- a/apps/api/src/edges/edges.service.ts
+++ b/apps/api/src/edges/edges.service.ts
@@ -1,0 +1,43 @@
+import { Injectable, Inject, NotFoundException } from '@nestjs/common';
+import { Pool } from 'pg';
+import { PG_POOL } from '../database/database.provider';
+
+@Injectable()
+export class EdgesService {
+  constructor(@Inject(PG_POOL) private readonly pg: Pool) {}
+
+  async create(canvasId: string, data: {
+    sourceId: string;
+    targetId: string;
+    label?: string;
+    style?: Record<string, unknown>;
+  }) {
+    const { rows } = await this.pg.query(
+      `INSERT INTO edges (canvas_id, source_id, target_id, label, style)
+       VALUES ($1, $2, $3, $4, $5)
+       RETURNING *`,
+      [
+        canvasId,
+        data.sourceId,
+        data.targetId,
+        data.label ?? null,
+        JSON.stringify(data.style ?? {}),
+      ],
+    );
+    return rows[0];
+  }
+
+  async findByCanvas(canvasId: string) {
+    const { rows } = await this.pg.query(
+      `SELECT * FROM edges WHERE canvas_id = $1`,
+      [canvasId],
+    );
+    return rows;
+  }
+
+  async remove(id: string) {
+    const { rowCount } = await this.pg.query(`DELETE FROM edges WHERE id = $1`, [id]);
+    if (!rowCount) throw new NotFoundException('Edge not found');
+    return { deleted: true };
+  }
+}


### PR DESCRIPTION
## Summary
- **Edge CRUD tools**: Agents can now create and delete edges (connections) between nodes using `create_edge` and `delete_edge` tools, with full WebSocket broadcast to viewers
- **Improved system prompt**: Better layout guidelines with node size hints, spatial awareness (bounding box), edge workflow instructions, and canvas title context
- **Richer canvas context**: Agent now receives existing edges, a spatial hint about occupied area, and the canvas title when starting a session

Closes #9, closes #10

## Test plan
- [ ] Invoke agent with a prompt that asks for connected concepts (e.g. "create a mind map about web development") and verify edges are created between nodes
- [ ] Verify edge creation broadcasts `edge:created` events to WebSocket viewers
- [ ] Verify agent places new nodes in empty space when canvas already has content
- [ ] Run `nest build` — compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)