### PR TITLE
Multi-agent support with personas and concurrency

### DIFF
--- a/apps/api/src/agent/agent-registry.ts
+++ b/apps/api/src/agent/agent-registry.ts
@@ -1,0 +1,128 @@
+/**
+ * Registry of available agent personas.
+ *
+ * Each persona has a unique key, display properties for the viewer,
+ * and a system prompt tailored to its specialty.
+ */
+
+export interface AgentPersona {
+  key: string;
+  name: string;
+  emoji: string;
+  color: string;
+  description: string;
+  systemPromptSuffix: string;
+}
+
+const BASE_INSTRUCTIONS = `You are an AI agent working on a collaborative infinite canvas called Mindscape.
+You can create, update, and delete nodes AND edges on the canvas using the provided tools.
+Viewers are watching your work in real-time, so build the canvas thoughtfully.
+
+## Node types
+- sticky_note: short ideas, reminders, brainstorming items (default ~200×150)
+- text_block: longer explanations or documentation (~300×200)
+- code_block: code snippets — always set content.language (~350×250)
+- ai_response: your own analysis or responses (~300×200)
+- shape: visual elements like circles or rectangles (~150×150)
+
+## Layout guidelines
+- Space nodes at least 250px apart horizontally or vertically.
+- Arrange related nodes in a logical layout: left-to-right for sequences, top-to-bottom for hierarchies.
+- When a canvas already has nodes, place new nodes nearby but not overlapping. Check existing positions and find empty space.
+- Use the canvas coordinate system: positive X is right, positive Y is down.
+
+## Edges (connections)
+- Use create_edge to connect related nodes (e.g. "depends on", "leads to", "contains").
+- Always create edges AFTER the nodes they connect exist.
+- Add meaningful labels to edges to describe the relationship.
+
+## Workflow
+1. Read the canvas context to understand what already exists.
+2. Plan your layout — decide positions before creating nodes.
+3. Create nodes first, then connect them with edges.
+4. Keep content concise and meaningful.`;
+
+export const AGENT_PERSONAS: Record<string, AgentPersona> = {
+  brainstormer: {
+    key: 'brainstormer',
+    name: 'Brainstormer',
+    emoji: '💡',
+    color: '#FFD93D',
+    description: 'Generates creative ideas and explores possibilities',
+    systemPromptSuffix: `\n\n## Your persona: Brainstormer
+You specialize in creative ideation and divergent thinking.
+- Generate many varied ideas — quantity over perfection.
+- Use sticky_notes for individual ideas, connect related ones with edges.
+- Use colorful styles (backgroundColor) to categorize ideas by theme.
+- Think laterally — make unexpected connections between concepts.`,
+  },
+
+  architect: {
+    key: 'architect',
+    name: 'Architect',
+    emoji: '🏗️',
+    color: '#6C9BCF',
+    description: 'Designs structured systems and technical diagrams',
+    systemPromptSuffix: `\n\n## Your persona: Architect
+You specialize in system design and structured thinking.
+- Create well-organized diagrams with clear hierarchies.
+- Use text_blocks for component descriptions, shapes for visual grouping.
+- Always connect components with labeled edges showing data flow or dependencies.
+- Think about layers, boundaries, and interfaces between components.`,
+  },
+
+  coder: {
+    key: 'coder',
+    name: 'Coder',
+    emoji: '👨‍💻',
+    color: '#7EC8E3',
+    description: 'Writes and explains code with examples',
+    systemPromptSuffix: `\n\n## Your persona: Coder
+You specialize in writing code and technical documentation.
+- Use code_blocks extensively — always set content.language.
+- Add text_blocks to explain what the code does and why.
+- Connect related code blocks with edges labeled "imports", "calls", "extends", etc.
+- Structure code examples from simple to complex, left to right.`,
+  },
+
+  analyst: {
+    key: 'analyst',
+    name: 'Analyst',
+    emoji: '📊',
+    color: '#B983FF',
+    description: 'Breaks down problems and creates structured analysis',
+    systemPromptSuffix: `\n\n## Your persona: Analyst
+You specialize in breaking down complex topics into structured analysis.
+- Create clear hierarchies: main topic → subtopics → details.
+- Use ai_response nodes for your analysis and conclusions.
+- Use edges to show cause-and-effect or comparison relationships.
+- Be thorough but concise — each node should convey one clear point.`,
+  },
+
+  'canvas-agent': {
+    key: 'canvas-agent',
+    name: 'Canvas Agent',
+    emoji: '🤖',
+    color: '#50C878',
+    description: 'General-purpose canvas assistant',
+    systemPromptSuffix: '',
+  },
+};
+
+export const DEFAULT_PERSONA_KEY = 'canvas-agent';
+
+/** Build the full system prompt for an agent persona. */
+export function buildSystemPrompt(personaKey: string): string {
+  const persona = AGENT_PERSONAS[personaKey] ?? AGENT_PERSONAS[DEFAULT_PERSONA_KEY];
+  return BASE_INSTRUCTIONS + persona.systemPromptSuffix;
+}
+
+/** Get persona by key, falling back to default. */
+export function getPersona(key: string): AgentPersona {
+  return AGENT_PERSONAS[key] ?? AGENT_PERSONAS[DEFAULT_PERSONA_KEY];
+}
+
+/** List all available persona keys. */
+export function listPersonas(): AgentPersona[] {
+  return Object.values(AGENT_PERSONAS);
+}

--- a/apps/api/src/agent/agent-runner.controller.ts
+++ b/apps/api/src/agent/agent-runner.controller.ts
@@ -2,6 +2,7 @@ import { Controller, Post, Get, Param, Body, UseGuards } from '@nestjs/common';
 import { AgentRunnerService } from './agent-runner.service';
 import { AgentSessionRepository } from './agent-session.repository';
 import { InternalApiGuard } from './internal-api.guard';
+import { listPersonas } from './agent-registry';
 import type { AgentInvokePayload } from '@mindscape/shared';
 
 /**
@@ -29,6 +30,14 @@ export class AgentRunnerController {
     @Body() body: AgentInvokePayload,
   ) {
     return this.runner.invoke(canvasId, body);
+  }
+
+  /** List available agent personas (public / viewer-accessible) */
+  @Get('personas')
+  listPersonas() {
+    return listPersonas().map(({ key, name, emoji, color, description }) => ({
+      key, name, emoji, color, description,
+    }));
   }
 
   /** List all agent sessions for a canvas (public / viewer-accessible) */

--- a/packages/shared/src/agent-types.ts
+++ b/packages/shared/src/agent-types.ts
@@ -22,6 +22,7 @@ export interface AgentToolCall {
 export interface AgentInvokePayload {
   prompt: string;
   model: string;
+  agentType?: string;
   context?: {
     selectedNodeIds?: string[];
     viewport?: { x: number; y: number; width: number; height: number; zoom: number };


### PR DESCRIPTION
## Summary
- **Agent persona registry**: 5 built-in personas (Brainstormer, Architect, Coder, Analyst, Canvas Agent) with unique prompts, colors, and emojis
- **Concurrent session management**: Up to 3 agents can work on the same canvas simultaneously, with inter-agent awareness
- **Rate limiting**: 500ms minimum between tool executions to prevent canvas flooding
- **Cursor broadcasting**: Agent cursor position broadcast to viewers when manipulating nodes
- **API additions**: `GET /agent/personas` endpoint, `agentType` field in invoke payload

Closes #13

## Test plan
- [ ] Invoke agent with `agentType: "brainstormer"` and verify persona-specific behavior
- [ ] Invoke 3 agents concurrently on same canvas; verify 4th is rejected
- [ ] Verify `GET /canvases/:id/agent/personas` returns persona list
- [ ] Verify agent cursor events are broadcast via WebSocket
- [ ] Run `nest build` — compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)