### PR TITLE
Display agent personas in viewer UI

### DIFF
--- a/apps/web/src/hooks/use-canvas-socket.ts
+++ b/apps/web/src/hooks/use-canvas-socket.ts
@@ -28,6 +28,7 @@ export function useCanvasSocket(canvasId: string) {
   const removeEdge = useCanvasStore((s) => s.removeEdge);
   const setPresence = useCanvasStore((s) => s.setPresence);
   const pushAgentActivity = useCanvasStore((s) => s.pushAgentActivity);
+  const upsertAgentCursor = useCanvasStore((s) => s.upsertAgentCursor);
 
   useEffect(() => {
     const socket: TypedSocket = io(`${WS_URL}/canvas`, {
@@ -80,6 +81,9 @@ export function useCanvasSocket(canvasId: string) {
     socket.on('agent:error', (data) =>
       pushAgentActivity({ sessionId: data.sessionId, type: 'error', data: data.error, timestamp: Date.now() }),
     );
+    socket.on('agent:cursor', (data) =>
+      upsertAgentCursor({ sessionId: data.sessionId, x: data.x, y: data.y, timestamp: Date.now() }),
+    );
 
     /* ── cleanup ─────────────────────────────────── */
     return () => {
@@ -99,6 +103,7 @@ export function useCanvasSocket(canvasId: string) {
     removeEdge,
     setPresence,
     pushAgentActivity,
+    upsertAgentCursor,
   ]);
 
   return socketRef;

--- a/apps/web/src/lib/agent-persona-client.ts
+++ b/apps/web/src/lib/agent-persona-client.ts
@@ -1,0 +1,54 @@
+import type { AgentStatus } from '@mindscape/shared';
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:4000';
+
+export interface AgentPersona {
+  key: string;
+  name: string;
+  emoji: string;
+  color: string;
+  description: string;
+}
+
+export interface AgentSessionSummary {
+  id: string;
+  agentName: string;
+  status: AgentStatus;
+  updatedAt: string;
+}
+
+function normalizePersona(raw: Record<string, unknown>): AgentPersona {
+  return {
+    key: String(raw.key ?? raw.agentType ?? raw.agent_type ?? 'unknown'),
+    name: String(raw.name ?? 'Agent'),
+    emoji: String(raw.emoji ?? '🤖'),
+    color: String(raw.color ?? '#6366f1'),
+    description: String(raw.description ?? ''),
+  };
+}
+
+function normalizeSession(raw: Record<string, unknown>): AgentSessionSummary {
+  const status = String(raw.status ?? 'idle') as AgentStatus;
+  return {
+    id: String(raw.id),
+    agentName: String(raw.agentName ?? raw.agent_name ?? 'unknown'),
+    status,
+    updatedAt: String(raw.updatedAt ?? raw.updated_at ?? ''),
+  };
+}
+
+async function fetchJson<T>(path: string): Promise<T> {
+  const res = await fetch(`${API_URL}${path}`, { cache: 'no-store' });
+  if (!res.ok) throw new Error(`Request failed: ${res.status}`);
+  return res.json() as Promise<T>;
+}
+
+export async function getAgentPersonas(canvasId: string): Promise<AgentPersona[]> {
+  const body = await fetchJson<Record<string, unknown>[]>(`/canvases/${canvasId}/agent/personas`);
+  return body.map(normalizePersona);
+}
+
+export async function getAgentSessions(canvasId: string): Promise<AgentSessionSummary[]> {
+  const body = await fetchJson<Record<string, unknown>[]>(`/canvases/${canvasId}/agent/sessions`);
+  return body.map(normalizeSession);
+}


### PR DESCRIPTION
## Summary
- fetch and normalize agent personas and sessions for canvas viewers (camelCase + snake_case safe)
- render persona emoji/name/color per activity event by mapping sessionId -> agent_name -> persona key
- add WebSocket-driven agent cursor tracking in the canvas store and render persona-labeled cursor dots with 3s fade-out
- show active persona badges in the HUD, updated in real time from agent status events and session data

## Verification
- cd apps/web && npx next build

Relates to #13