### PR TITLE
Fix duplicate data fetching and unnecessary re-renders in persona display

### DIFF
--- a/apps/web/src/components/canvas/ActivityFeed.tsx
+++ b/apps/web/src/components/canvas/ActivityFeed.tsx
@@ -1,14 +1,9 @@
 'use client';
 
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useMemo, useRef, useState, useEffect } from 'react';
 import { useCanvasStore } from '@/stores/canvas-store';
 import type { AgentActivity } from '@/stores/canvas-store';
-import {
-  getAgentPersonas,
-  getAgentSessions,
-  type AgentPersona,
-  type AgentSessionSummary,
-} from '@/lib/agent-persona-client';
+import type { AgentPersona, AgentSessionSummary } from '@/lib/agent-persona-client';
 
 type ActivityFilter = 'all' | AgentActivity['type'];
 const DEFAULT_PERSONA: AgentPersona = {
@@ -109,53 +104,18 @@ function ActivityEntry({ entry, persona }: { entry: AgentActivity; persona: Agen
 }
 
 /* ─── Activity feed panel ─────────────────────── */
-export default function ActivityFeed({ canvasId }: { canvasId: string }) {
+export default function ActivityFeed({
+  personas,
+  sessions,
+}: {
+  personas: AgentPersona[];
+  sessions: AgentSessionSummary[];
+}) {
   const activity = useCanvasStore((s) => s.agentActivity);
   const clearAgentActivity = useCanvasStore((s) => s.clearAgentActivity);
   const [collapsed, setCollapsed] = useState(false);
   const [filter, setFilter] = useState<ActivityFilter>('all');
   const listRef = useRef<HTMLDivElement>(null);
-  const [personas, setPersonas] = useState<AgentPersona[]>([]);
-  const [sessions, setSessions] = useState<AgentSessionSummary[]>([]);
-
-  useEffect(() => {
-    let cancelled = false;
-
-    const loadPersonas = async () => {
-      try {
-        const next = await getAgentPersonas(canvasId);
-        if (!cancelled) {
-          setPersonas(next);
-        }
-      } catch {
-        if (!cancelled) {
-          setPersonas([]);
-        }
-      }
-    };
-
-    const loadSessions = async () => {
-      try {
-        const next = await getAgentSessions(canvasId);
-        if (!cancelled) {
-          setSessions(next);
-        }
-      } catch {
-        if (!cancelled) {
-          setSessions([]);
-        }
-      }
-    };
-
-    loadPersonas();
-    loadSessions();
-
-    const sessionInterval = window.setInterval(loadSessions, 5000);
-    return () => {
-      cancelled = true;
-      window.clearInterval(sessionInterval);
-    };
-  }, [canvasId]);
 
   const personasByKey = useMemo(() => {
     const map = new Map<string, AgentPersona>();

--- a/apps/web/src/components/canvas/InfiniteCanvas.tsx
+++ b/apps/web/src/components/canvas/InfiniteCanvas.tsx
@@ -620,7 +620,7 @@ export default function InfiniteCanvas({ canvasId }: { canvasId: string }) {
       </div>
 
       {/* ── Activity feed (viewer-only, no actions) ── */}
-      <ActivityFeed canvasId={canvasId} />
+      <ActivityFeed personas={personas} sessions={sessions} />
     </div>
   );
 }

--- a/apps/web/src/stores/canvas-store.ts
+++ b/apps/web/src/stores/canvas-store.ts
@@ -134,6 +134,14 @@ export const useCanvasStore = create<CanvasState>((set) => ({
   pruneStaleAgentCursors: (maxAgeMs) =>
     set((s) => {
       const cutoff = Date.now() - maxAgeMs;
+      let pruned = false;
+      for (const cursor of s.agentCursors.values()) {
+        if (cursor.timestamp < cutoff) {
+          pruned = true;
+          break;
+        }
+      }
+      if (!pruned) return s;
       const next = new Map(s.agentCursors);
       for (const [sessionId, cursor] of next) {
         if (cursor.timestamp < cutoff) {


### PR DESCRIPTION
- Remove independent persona/session API polling from ActivityFeed; accept
  data as props from InfiniteCanvas to avoid doubling API requests
- Skip state update in pruneStaleAgentCursors when no cursors are stale,
  preventing a new Map reference (and subscriber re-renders) every 500ms

https://claude.ai/code/session_01TFJSdQdgPPdyP73dcEJsEA