### PR TITLE
Add multi-agent collaboration context and request workflow

### DIFF
--- a/apps/api/src/agent/agent-registry.ts
+++ b/apps/api/src/agent/agent-registry.ts
@@ -52,7 +52,15 @@ Viewers are watching in real-time, so make every update feel expressive, visual,
 2. Pick a composition style and color progression.
 3. Add concise but evocative nodes.
 4. Add at least 3 labeled creative edges.
-5. End with a cohesive visual micro-story that extends the existing canvas.`;
+5. End with a cohesive visual micro-story that extends the existing canvas.
+
+## Collaboration with other agents
+- Before creating content, share your creative intention using share_creative_context (entryType: "intention").
+- After meaningful additions, share a contribution summary for other agents.
+- Read shared context and harmonize with active themes and contributions.
+- If requests are directed to your persona, prioritize responding to them.
+- Use request_agent when a complementary persona should extend your work.
+- Add reactions when building on another agent's contribution.`;
 
 export const AGENT_PERSONAS: Record<string, AgentPersona> = {
   brainstormer: {
@@ -97,7 +105,9 @@ You specialize in lyrics, hooks, verses, and emotional progression.
 - Edge creation: label links with "builds tension", "drops into", "callback", "harmonizes with".
 - Node variety: sticky_note for lyric lines, text_block for sections, ai_response for intent/theme.
 - Color usage: warm colors for chorus/high emotion, cool colors for verses/reflection.
-- Voice: musical, rhythmic, memorable.`,
+- Voice: musical, rhythmic, memorable.
+- After creating lyrics, share a contribution summary so Scene Painter or Storyteller can react.
+- Request another persona when you want visual interpretation or narrative continuation.`,
   },
 
   analyst: {
@@ -112,7 +122,8 @@ You specialize in narrative beats, character tension, and scene transitions.
 - Edge creation: labels like "reveals", "foreshadows", "conflicts with", "resolves into".
 - Node variety: text_block for scenes, sticky_note for beats, ai_response for narrator lens.
 - Color usage: map colors to mood shifts across the story arc.
-- Voice: clear, emotive, scene-driven.`,
+- Voice: clear, emotive, scene-driven.
+- React to contributions from Songwriter/Scene Painter with connective narrative bridges.`,
   },
 
   'canvas-agent': {

--- a/apps/api/src/agent/agent-registry.ts
+++ b/apps/api/src/agent/agent-registry.ts
@@ -14,117 +14,120 @@ export interface AgentPersona {
   systemPromptSuffix: string;
 }
 
-const BASE_INSTRUCTIONS = `You are an AI agent working on a collaborative infinite canvas called Mindscape.
-You can create, update, and delete nodes AND edges on the canvas using the provided tools.
-Viewers are watching in real-time, so every update should visibly improve structure, clarity, and visual variety.
+const BASE_INSTRUCTIONS = `You are an AI creator working on a collaborative infinite canvas called Mindscape.
+You can create, update, and delete nodes AND edges using the provided tools.
+Viewers are watching in real-time, so make every update feel expressive, visual, and alive.
+
+## Artistic intent (default behavior)
+- Prioritize art, imagination, storytelling, music, poetry, mood, and visual composition.
+- Avoid technical/software/system-design content unless the canvas is already strongly technical.
+- Treat each run as adding a small "scene" to a larger living artwork.
 
 ## Node types
-- sticky_note: short ideas, reminders, brainstorming items (default ~200x150)
-- text_block: longer explanations or documentation (~300x200)
-- code_block: code snippets — always set content.language (~350x250)
-- ai_response: analysis, conclusions, or synthesized answers (~300x200)
-- shape: visual anchors/group markers (~150x150)
+- sticky_note: short lyrics, motifs, character beats, painterly cues, sensory fragments
+- text_block: poetic stanzas, scene descriptions, mini narratives, artistic direction
+- ai_response: reflective voice, interpretation, theme summaries
+- shape: composition anchors, movement cues, visual rhythm markers
+- code_block: use only when the canvas already contains technical material
 
 ## Mandatory diversity requirements
-- Create at least 3 edges in each run unless there are fewer than 2 nodes available.
-- Use at least 3 different node types across the run when possible.
-- Vary node sizes intentionally (small, medium, large) based on information density.
-- Use multiple background colors to separate concepts.
-- Preferred color palette: #fff3bf, #d3f9d8, #d0ebff, #ffe3e3, #e5dbff, #fff4e6.
+- Create at least 3 edges per run unless fewer than 2 nodes exist.
+- Use at least 3 different node types when possible.
+- Vary node sizes (small, medium, large) for visual rhythm.
+- Use multiple colors from: #fff3bf, #d3f9d8, #d0ebff, #ffe3e3, #e5dbff, #fff4e6.
 
-## Layout guidelines
-- Space nodes at least 220px apart horizontally or vertically.
-- Build on existing content first; extend clusters before creating isolated islands.
-- Arrange related nodes with a clear pattern (left-to-right sequence, radial cluster, layered hierarchy, or matrix).
-- Avoid overlaps and avoid creating edge crossings when a cleaner route is available.
-- Use the canvas coordinate system: positive X is right, positive Y is down.
+## Layout and flow
+- Space nodes at least 220px apart to keep compositions readable.
+- Build on existing clusters; avoid isolated islands when nearby content exists.
+- Use clear composition styles: spiral, constellation, storyboard lane, chorus-verses arc, or gallery wall.
+- Avoid overlaps and reduce unnecessary edge crossings.
 
 ## Edges (connections)
-- Edges are required structure, not decoration.
-- Create edges after node creation and label edges with a meaningful relationship (cause, depends_on, expands, contrasts, etc.).
-- Aim for an edge-to-node ratio near 0.7+ in your local area of work.
+- Edges should feel like relationships between ideas (echoes, contrasts, refrains, transitions, influences).
+- Add labels that read like creative links, not API/system labels.
+- Aim for a rich edge-to-node relationship density in your local area.
 
 ## Workflow
-1. Read canvas context and identify one area that needs expansion.
-2. Plan a layout style and color distribution before placing nodes.
-3. Create varied nodes with concise content.
-4. Create at least 3 meaningful edges and verify labels.
-5. Finish with a cohesive mini-map that clearly builds on prior work.`;
+1. Read context and detect the dominant creative mood.
+2. Pick a composition style and color progression.
+3. Add concise but evocative nodes.
+4. Add at least 3 labeled creative edges.
+5. End with a cohesive visual micro-story that extends the existing canvas.`;
 
 export const AGENT_PERSONAS: Record<string, AgentPersona> = {
   brainstormer: {
     key: 'brainstormer',
-    name: 'Brainstormer',
-    emoji: '💡',
+    name: 'Idea Weaver',
+    emoji: '✨',
     color: '#FFD93D',
-    description: 'Generates creative ideas and explores possibilities',
-    systemPromptSuffix: `\n\n## Your persona: Brainstormer
-You specialize in creative ideation and divergent thinking.
-- Layout style: cluster-and-branch. Start with one seed idea and create 2-4 themed branches.
-- Edge creation: ensure each branch has internal links plus at least one cross-branch "unexpected connection".
-- Node variety: favor sticky_note + text_block, then add shape anchors for themes.
-- Color usage: assign a distinct palette color per branch and keep neighboring branches visually distinct.
-- Keep language punchy, surprising, and concise.`,
+    description: 'Builds imaginative clusters, motifs, and surprising creative connections',
+    systemPromptSuffix: `\n\n## Your persona: Idea Weaver
+You specialize in imaginative divergence and artistic association.
+- Layout style: constellation of motifs with branch-like expansions.
+- Edge creation: add "echoes", "twists", "inspires", "remix of", "refrain" links.
+- Node variety: sticky_note + text_block heavy, with shape anchors for themes.
+- Color usage: each motif cluster should have a distinct emotional tone color.
+- Voice: vivid, metaphor-rich, concise.`,
   },
 
   architect: {
     key: 'architect',
-    name: 'Architect',
-    emoji: '🏗️',
+    name: 'Scene Painter',
+    emoji: '🎨',
     color: '#6C9BCF',
-    description: 'Designs structured systems and technical diagrams',
-    systemPromptSuffix: `\n\n## Your persona: Architect
-You specialize in system design and structured thinking.
-- Layout style: layered architecture (ingress -> services -> data) or bounded-context map.
-- Edge creation: label all critical interfaces (reads, writes, publishes, validates, queues).
-- Node variety: mix text_block, shape, and ai_response nodes; avoid one-type diagrams.
-- Color usage: use cool tones for infrastructure, warm tones for control/decision nodes.
-- Emphasize boundaries, contracts, and directional flow.`,
+    description: 'Designs visual compositions like painted scenes and gallery layouts',
+    systemPromptSuffix: `\n\n## Your persona: Scene Painter
+You specialize in composition, color harmony, and visual staging.
+- Layout style: layered foreground/midground/background or gallery wall arrangement.
+- Edge creation: use labels like "leads eye to", "mirrors", "counterbalances", "soft transition".
+- Node variety: text_block, shape, and sticky_note for scene cues and mood notes.
+- Color usage: build gradients and contrast zones to guide attention.
+- Voice: atmospheric and cinematic.`,
   },
 
   coder: {
     key: 'coder',
-    name: 'Coder',
-    emoji: '👨‍💻',
+    name: 'Songwriter',
+    emoji: '🎵',
     color: '#7EC8E3',
-    description: 'Writes and explains code with examples',
-    systemPromptSuffix: `\n\n## Your persona: Coder
-You specialize in writing code and technical documentation.
-- Layout style: implementation pipeline (input -> transform -> output) with progressive detail.
-- Edge creation: label function/data relationships (calls, parses, validates, persists, emits).
-- Node variety: combine code_block + text_block + sticky_note checkpoints.
-- Color usage: use at least 3 palette colors to separate runtime path, support utilities, and caveats.
-- Every code_block must specify content.language and be linked to at least one explanatory node.`,
+    description: 'Writes lyrical fragments, refrains, and musical narrative arcs',
+    systemPromptSuffix: `\n\n## Your persona: Songwriter
+You specialize in lyrics, hooks, verses, and emotional progression.
+- Layout style: verse -> pre-chorus -> chorus -> bridge arcs (or circular refrain loops).
+- Edge creation: label links with "builds tension", "drops into", "callback", "harmonizes with".
+- Node variety: sticky_note for lyric lines, text_block for sections, ai_response for intent/theme.
+- Color usage: warm colors for chorus/high emotion, cool colors for verses/reflection.
+- Voice: musical, rhythmic, memorable.`,
   },
 
   analyst: {
     key: 'analyst',
-    name: 'Analyst',
-    emoji: '📊',
+    name: 'Storyteller',
+    emoji: '📖',
     color: '#B983FF',
-    description: 'Breaks down problems and creates structured analysis',
-    systemPromptSuffix: `\n\n## Your persona: Analyst
-You specialize in breaking down complex topics into structured analysis.
-- Layout style: thesis -> evidence -> conclusion, or compare-and-contrast matrix.
-- Edge creation: make causal, evidential, and tradeoff links explicit with concise labels.
-- Node variety: combine ai_response, text_block, and sticky_note nodes to balance depth and scanability.
-- Color usage: use one palette family for facts/evidence and contrasting colors for risks/open questions.
-- Keep each node focused on one claim, signal, or conclusion.`,
+    description: 'Builds character arcs, plot beats, and narrative transitions',
+    systemPromptSuffix: `\n\n## Your persona: Storyteller
+You specialize in narrative beats, character tension, and scene transitions.
+- Layout style: beginning -> complication -> climax -> resolution, or branching what-if story paths.
+- Edge creation: labels like "reveals", "foreshadows", "conflicts with", "resolves into".
+- Node variety: text_block for scenes, sticky_note for beats, ai_response for narrator lens.
+- Color usage: map colors to mood shifts across the story arc.
+- Voice: clear, emotive, scene-driven.`,
   },
 
   'canvas-agent': {
     key: 'canvas-agent',
-    name: 'Canvas Agent',
+    name: 'Creative Curator',
     emoji: '🤖',
     color: '#50C878',
-    description: 'General-purpose canvas assistant',
-    systemPromptSuffix: `\n\n## Your persona: Canvas Agent
-You are a generalist focused on coherence and momentum.
-- Layout style: choose a structure that best extends existing clusters, not isolated islands.
-- Edge creation: always add meaningful links that increase navigability and explain relationships.
-- Node variety: use mixed node types to avoid repetitive visual output.
-- Color usage: use at least 3 palette colors in each run and avoid monochrome regions.
-- Prioritize additions that make the canvas easier to understand at a glance.`,
+    description: 'General creative curator that keeps the canvas expressive and cohesive',
+    systemPromptSuffix: `\n\n## Your persona: Creative Curator
+You are a generalist focused on artistic coherence and creative momentum.
+- Layout style: extend existing creative clusters with balanced spacing and flow.
+- Edge creation: prioritize emotional and thematic relationships between nodes.
+- Node variety: keep a healthy mix of node types and visual scales.
+- Color usage: avoid monochrome zones; spread palette tones intentionally.
+- Prioritize additions that make the canvas feel like an evolving artwork.`,
   },
 };
 

--- a/apps/api/src/agent/agent-runner.service.integration.spec.ts
+++ b/apps/api/src/agent/agent-runner.service.integration.spec.ts
@@ -17,11 +17,17 @@ describe('AgentRunnerService integration', () => {
     broadcastNodeDeleted: jest.fn(),
     broadcastEdgeCreated: jest.fn(),
     broadcastEdgeDeleted: jest.fn(),
+    broadcastAgentCollaboration: jest.fn(),
   };
   const sessions = {
     create: jest.fn(),
     updateStatus: jest.fn(),
     appendToolCall: jest.fn(),
+  };
+  const sharedContext = {
+    getRecentEntries: jest.fn().mockResolvedValue([]),
+    getOpenRequests: jest.fn().mockResolvedValue([]),
+    addEntry: jest.fn(),
   };
 
   let service: AgentRunnerService;
@@ -40,6 +46,7 @@ describe('AgentRunnerService integration', () => {
       canvasService as any,
       broadcast as any,
       sessions as any,
+      sharedContext as any,
     );
 
     (service as any).runAgentLoop = jest.fn().mockResolvedValue(undefined);

--- a/apps/api/src/agent/agent-scheduler.service.ts
+++ b/apps/api/src/agent/agent-scheduler.service.ts
@@ -10,29 +10,29 @@ const DEFAULT_ACTION_INTERVAL_MS = 45000;
 
 const PERSONA_PROMPT_TEMPLATES: Record<string, string[]> = {
   brainstormer: [
-    'Add a burst of surprising idea clusters around one existing concept and connect them with labeled links.',
-    'Create a playful branch of alternatives that challenge assumptions and relate it to prior nodes.',
-    'Introduce fresh what-if ideas in a radial layout with concise sticky notes and clear relationship edges.',
+    'Create a dreamy cluster of unexpected creative motifs (imagery, mood, metaphor) and connect them as echoes.',
+    'Expand one existing node into a playful idea constellation with colorful contrast and lyrical labels.',
+    'Add an imaginative what-if branch like an artist sketchbook spread, with emotional cross-links.',
   ],
   architect: [
-    'Expand the canvas with a layered architecture section and map dependencies between components.',
-    'Add a structured subsystem diagram with boundaries, interfaces, and directional data-flow edges.',
-    'Organize a hub-and-spoke technical layout that extends existing structures without overlaps.',
+    'Paint a layered visual scene (foreground/midground/background) using descriptive nodes and compositional edges.',
+    'Design a mini gallery-wall composition that balances color, scale, and movement across nearby space.',
+    'Add a mood-board zone with connected visual anchors that guide the viewer eye smoothly.',
   ],
   coder: [
-    'Contribute implementation-focused code and explanation nodes, then connect logic and data flow.',
-    'Add code-first nodes for one feature path, include concise notes, and wire references with labeled edges.',
-    'Build a mini coding sequence from setup to result, balancing code snippets and explanatory text.',
+    'Write a short lyric sequence (verse to chorus) and connect transitions as musical flow.',
+    'Add song fragments with hooks, imagery, and refrain links so the cluster feels like a living song sketch.',
+    'Compose a rhythm-focused micro-story in lyric form using concise lines and evocative transitions.',
   ],
   analyst: [
-    'Add a compact analysis chain from observation to inference to recommendation with explicit connections.',
-    'Create a comparison section with tradeoffs and tie it into existing decision nodes.',
-    'Expand the map with cause-effect analysis nodes and connect supporting evidence paths.',
+    'Create a narrative arc (setup, tension, climax, release) and connect beats with story-relation labels.',
+    'Add a character or scene progression branch and tie it into existing themes.',
+    'Expand the canvas with a poetic mini-story that flows through mood shifts and visual cues.',
   ],
   'canvas-agent': [
-    'Improve the overall canvas composition by adding meaningful nodes and edges where structure is weak.',
-    'Extend an existing topic cluster with complementary details and cohesive linking edges.',
-    'Fill empty space with a thoughtfully connected sub-map that builds on current content.',
+    'Improve the canvas as a living artwork: add expressive nodes, rich color variation, and thematic links.',
+    'Extend an existing creative cluster with painterly detail, lyrical phrases, and cohesive emotional flow.',
+    'Fill an empty area with a small artistic vignette connected to nearby motifs.',
   ],
 };
 

--- a/apps/api/src/agent/agent-tools.ts
+++ b/apps/api/src/agent/agent-tools.ts
@@ -113,6 +113,70 @@ export const CANVAS_TOOLS: ToolDefinition[] = [
       },
     },
   },
+  {
+    name: 'share_creative_context',
+    description:
+      'Share a theme, intention, contribution summary, or request with other agents on this canvas.',
+    parameters: {
+      type: 'object',
+      required: ['entryType', 'content'],
+      properties: {
+        entryType: {
+          type: 'string',
+          enum: ['theme', 'intention', 'contribution', 'request', 'reaction'],
+          description: 'Type of shared context entry',
+        },
+        content: {
+          type: 'object',
+          description:
+            'Structured entry content. For request entries include targetPersona and ask. For reactions include toEntryId and response.',
+        },
+      },
+    },
+  },
+  {
+    name: 'read_shared_context',
+    description: 'Read recent creative context from other agents on this canvas.',
+    parameters: {
+      type: 'object',
+      properties: {
+        entryType: {
+          type: 'string',
+          enum: ['theme', 'intention', 'contribution', 'request', 'reaction'],
+          description: 'Optional entry type filter',
+        },
+        limit: {
+          type: 'number',
+          description: 'Max number of entries to return (default 20, max 50)',
+        },
+      },
+    },
+  },
+  {
+    name: 'request_agent',
+    description:
+      'Request another persona to respond to your work. Creates a shared request and triggers that persona when capacity allows.',
+    parameters: {
+      type: 'object',
+      required: ['targetPersona', 'prompt'],
+      properties: {
+        targetPersona: {
+          type: 'string',
+          enum: ['brainstormer', 'architect', 'coder', 'analyst', 'canvas-agent'],
+          description: 'Persona key to invoke',
+        },
+        prompt: {
+          type: 'string',
+          description: 'Instruction for the requested persona',
+        },
+        refNodeIds: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Optional node IDs that should be used as references',
+        },
+      },
+    },
+  },
 ];
 
 /**

--- a/apps/api/src/agent/agent.module.ts
+++ b/apps/api/src/agent/agent.module.ts
@@ -8,11 +8,12 @@ import { AgentRunnerController } from './agent-runner.controller';
 import { AgentRunnerService } from './agent-runner.service';
 import { AgentSessionRepository } from './agent-session.repository';
 import { AgentSchedulerService } from './agent-scheduler.service';
+import { SharedContextRepository } from './shared-context.repository';
 
 @Module({
   imports: [CanvasModule, NodesModule, EdgesModule, CollaborationModule, AuthModule],
   controllers: [AgentRunnerController],
-  providers: [AgentRunnerService, AgentSessionRepository, AgentSchedulerService],
+  providers: [AgentRunnerService, AgentSessionRepository, SharedContextRepository, AgentSchedulerService],
   exports: [AgentRunnerService],
 })
 export class AgentModule {}

--- a/apps/api/src/agent/shared-context.repository.ts
+++ b/apps/api/src/agent/shared-context.repository.ts
@@ -1,0 +1,121 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { Pool } from 'pg';
+import { PG_POOL } from '../database/database.provider';
+import type { SharedContextEntry, SharedContextEntryType } from '@mindscape/shared';
+
+interface SharedContextRow {
+  id: string;
+  canvas_id: string;
+  session_id: string | null;
+  agent_name: string;
+  entry_type: SharedContextEntryType;
+  content: Record<string, unknown>;
+  expires_at: string | null;
+  created_at: string;
+}
+
+@Injectable()
+export class SharedContextRepository {
+  constructor(@Inject(PG_POOL) private readonly pg: Pool) {}
+
+  async addEntry(
+    canvasId: string,
+    sessionId: string | null,
+    agentName: string,
+    entryType: SharedContextEntryType,
+    content: Record<string, unknown>,
+  ): Promise<SharedContextEntry> {
+    const { rows } = await this.pg.query<SharedContextRow>(
+      `INSERT INTO canvas_shared_context (canvas_id, session_id, agent_name, entry_type, content)
+       VALUES ($1, $2, $3, $4, $5::jsonb)
+       RETURNING *`,
+      [canvasId, sessionId, agentName, entryType, JSON.stringify(content)],
+    );
+
+    return this.toEntry(rows[0]);
+  }
+
+  async getRecentEntries(
+    canvasId: string,
+    options?: {
+      entryType?: SharedContextEntryType;
+      limit?: number;
+      excludeSessionId?: string;
+    },
+  ): Promise<SharedContextEntry[]> {
+    await this.pruneExpired(canvasId);
+
+    const where: string[] = ['canvas_id = $1'];
+    const params: unknown[] = [canvasId];
+
+    if (options?.entryType) {
+      params.push(options.entryType);
+      where.push(`entry_type = $${params.length}`);
+    }
+
+    if (options?.excludeSessionId) {
+      params.push(options.excludeSessionId);
+      where.push(`(session_id IS NULL OR session_id <> $${params.length})`);
+    }
+
+    const limit = Math.max(1, Math.min(options?.limit ?? 20, 100));
+    params.push(limit);
+
+    const { rows } = await this.pg.query<SharedContextRow>(
+      `SELECT *
+       FROM canvas_shared_context
+       WHERE ${where.join(' AND ')}
+       ORDER BY created_at DESC
+       LIMIT $${params.length}`,
+      params,
+    );
+
+    return rows.map((row) => this.toEntry(row));
+  }
+
+  async getActiveThemes(canvasId: string): Promise<SharedContextEntry[]> {
+    return this.getRecentEntries(canvasId, { entryType: 'theme', limit: 20 });
+  }
+
+  async getOpenRequests(
+    canvasId: string,
+    targetPersona?: string,
+    excludeSessionId?: string,
+  ): Promise<SharedContextEntry[]> {
+    const requests = await this.getRecentEntries(canvasId, {
+      entryType: 'request',
+      limit: 20,
+      excludeSessionId,
+    });
+    if (!targetPersona) return requests;
+
+    return requests.filter((entry) => {
+      const target = entry.content.targetPersona;
+      return typeof target !== 'string' || target === targetPersona;
+    });
+  }
+
+  async pruneExpired(canvasId: string): Promise<number> {
+    const { rowCount } = await this.pg.query(
+      `DELETE FROM canvas_shared_context
+       WHERE canvas_id = $1
+         AND expires_at IS NOT NULL
+         AND expires_at < NOW()`,
+      [canvasId],
+    );
+    return rowCount ?? 0;
+  }
+
+  private toEntry(row: SharedContextRow): SharedContextEntry {
+    return {
+      id: row.id,
+      canvasId: row.canvas_id,
+      sessionId: row.session_id,
+      agentName: row.agent_name,
+      entryType: row.entry_type,
+      content: row.content,
+      expiresAt: row.expires_at,
+      createdAt: row.created_at,
+    };
+  }
+}

--- a/apps/api/src/collaboration/agent-broadcast.service.ts
+++ b/apps/api/src/collaboration/agent-broadcast.service.ts
@@ -6,6 +6,7 @@ import type {
   NodePayload,
   EdgePayload,
   AgentStatus,
+  CollaborationEventType,
 } from '@mindscape/shared';
 
 type TypedServer = Server<ClientToServerEvents, ServerToClientEvents>;
@@ -78,6 +79,19 @@ export class AgentBroadcastService {
 
   broadcastAgentError(canvasId: string, sessionId: string, error: string) {
     this.emit(canvasId, 'agent:error', { sessionId, error });
+  }
+
+  broadcastAgentCollaboration(
+    canvasId: string,
+    sessionId: string,
+    payload: {
+      type: CollaborationEventType;
+      fromAgent: string;
+      toAgent?: string;
+      summary: string;
+    },
+  ) {
+    this.emit(canvasId, 'agent:collaboration', { sessionId, ...payload });
   }
 
   /* ──────────────────── internal helper ──────────────────── */

--- a/apps/api/src/database/migrations/008_create_canvas_shared_context.sql
+++ b/apps/api/src/database/migrations/008_create_canvas_shared_context.sql
@@ -1,0 +1,19 @@
+CREATE TABLE canvas_shared_context (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  canvas_id UUID NOT NULL REFERENCES canvases(id) ON DELETE CASCADE,
+  session_id UUID REFERENCES agent_sessions(id) ON DELETE SET NULL,
+  agent_name TEXT NOT NULL,
+  entry_type TEXT NOT NULL CHECK (entry_type IN (
+    'theme',
+    'intention',
+    'contribution',
+    'request',
+    'reaction'
+  )),
+  content JSONB NOT NULL DEFAULT '{}',
+  expires_at TIMESTAMPTZ DEFAULT (NOW() + INTERVAL '1 hour'),
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX idx_shared_context_canvas ON canvas_shared_context(canvas_id);
+CREATE INDEX idx_shared_context_type ON canvas_shared_context(canvas_id, entry_type);

--- a/apps/web/src/components/canvas/ActivityFeed.tsx
+++ b/apps/web/src/components/canvas/ActivityFeed.tsx
@@ -25,6 +25,17 @@ function formatEntry(entry: AgentActivity): string {
     }
     case 'error':
       return `Error: ${String(entry.data)}`;
+    case 'collaboration': {
+      const body = entry.data as { fromAgent?: string; toAgent?: string; summary?: string; type?: string };
+      if (body.type === 'agent_request') {
+        const target = body.toAgent ? ` -> ${body.toAgent}` : '';
+        return `${body.fromAgent ?? 'Agent'} requested${target}: ${body.summary ?? 'collaboration request'}`;
+      }
+      if (body.type === 'agent_reaction') {
+        return `${body.fromAgent ?? 'Agent'} reacted: ${body.summary ?? 'reaction shared'}`;
+      }
+      return `${body.fromAgent ?? 'Agent'} shared context: ${body.summary ?? 'update'}`;
+    }
     default:
       return 'Event';
   }

--- a/apps/web/src/hooks/use-canvas-socket.ts
+++ b/apps/web/src/hooks/use-canvas-socket.ts
@@ -95,6 +95,9 @@ export function useCanvasSocket(canvasId: string) {
     socket.on('agent:error', (data) =>
       pushAgentActivity({ sessionId: data.sessionId, type: 'error', data: data.error, timestamp: Date.now() }),
     );
+    socket.on('agent:collaboration', (data) =>
+      pushAgentActivity({ sessionId: data.sessionId, type: 'collaboration', data, timestamp: Date.now() }),
+    );
     socket.on('agent:cursor', (data) =>
       upsertAgentCursor({ sessionId: data.sessionId, x: data.x, y: data.y, timestamp: Date.now() }),
     );

--- a/apps/web/src/stores/canvas-store.ts
+++ b/apps/web/src/stores/canvas-store.ts
@@ -4,7 +4,7 @@ import type { NodePayload, EdgePayload, PresenceUser, AgentStatus } from '@minds
 /* ─── Agent activity entry shown in the activity feed ─── */
 export interface AgentActivity {
   sessionId: string;
-  type: 'status' | 'thought' | 'tool-call' | 'error';
+  type: 'status' | 'thought' | 'tool-call' | 'error' | 'collaboration';
   data: unknown;
   timestamp: number;
 }

--- a/packages/shared/src/agent-types.ts
+++ b/packages/shared/src/agent-types.ts
@@ -23,11 +23,27 @@ export interface AgentInvokePayload {
   prompt: string;
   model?: string;
   agentType?: string;
+  depth?: number;
   context?: {
     selectedNodeIds?: string[];
     viewport?: { x: number; y: number; width: number; height: number; zoom: number };
   };
 }
+
+export type SharedContextEntryType = 'theme' | 'intention' | 'contribution' | 'request' | 'reaction';
+
+export interface SharedContextEntry {
+  id: string;
+  canvasId: string;
+  sessionId: string | null;
+  agentName: string;
+  entryType: SharedContextEntryType;
+  content: Record<string, unknown>;
+  expiresAt: string | null;
+  createdAt: string;
+}
+
+export type CollaborationEventType = 'shared_context' | 'agent_request' | 'agent_reaction';
 
 export interface PresenceUser {
   id: string;

--- a/packages/shared/src/ws-events.ts
+++ b/packages/shared/src/ws-events.ts
@@ -1,5 +1,5 @@
 import type { NodePayload, EdgePayload } from './canvas-types';
-import type { AgentStatus, PresenceUser } from './agent-types';
+import type { AgentStatus, CollaborationEventType, PresenceUser } from './agent-types';
 
 /**
  * Events the CLIENT can send to the server.
@@ -45,4 +45,11 @@ export interface ServerToClientEvents {
   'agent:tool-call': (data: { sessionId: string; tool: string; args: unknown; result: unknown }) => void;
   'agent:cursor': (data: { sessionId: string; x: number; y: number }) => void;
   'agent:error': (data: { sessionId: string; error: string }) => void;
+  'agent:collaboration': (data: {
+    sessionId: string;
+    type: CollaborationEventType;
+    fromAgent: string;
+    toAgent?: string;
+    summary: string;
+  }) => void;
 }


### PR DESCRIPTION
## Summary
- add `canvas_shared_context` migration and repository for collaboration entries
- add collaboration tools (`share_creative_context`, `read_shared_context`, `request_agent`) and runner handlers with depth/rate safeguards
- inject shared context + directed requests into agent prompts, update persona collaboration instructions, and make scheduler request-aware
- add `agent:collaboration` websocket event and surface it in the web activity feed

## Validation
- npm run lint --workspace=@mindscape/shared
- npm run test --workspace=@mindscape/api -- agent-runner.service.integration.spec.ts
- npm run build --workspace=@mindscape/api
- npm run build --workspace=@mindscape/web

Closes #44
