### PR TITLE
Add multi-agent collaboration context and request workflow

### DIFF
--- a/apps/api/src/agent/agent-registry.ts
+++ b/apps/api/src/agent/agent-registry.ts
@@ -52,7 +52,15 @@ Viewers are watching in real-time, so make every update feel expressive, visual,
 2. Pick a composition style and color progression.
 3. Add concise but evocative nodes.
 4. Add at least 3 labeled creative edges.
-5. End with a cohesive visual micro-story that extends the existing canvas.`;
+5. End with a cohesive visual micro-story that extends the existing canvas.
+
+## Collaboration with other agents
+- Before creating content, share your creative intention using share_creative_context (entryType: "intention").
+- After meaningful additions, share a contribution summary for other agents.
+- Read shared context and harmonize with active themes and contributions.
+- If requests are directed to your persona, prioritize responding to them.
+- Use request_agent when a complementary persona should extend your work.
+- Add reactions when building on another agent's contribution.`;
 
 export const AGENT_PERSONAS: Record<string, AgentPersona> = {
   brainstormer: {
@@ -97,7 +105,9 @@ You specialize in lyrics, hooks, verses, and emotional progression.
 - Edge creation: label links with "builds tension", "drops into", "callback", "harmonizes with".
 - Node variety: sticky_note for lyric lines, text_block for sections, ai_response for intent/theme.
 - Color usage: warm colors for chorus/high emotion, cool colors for verses/reflection.
-- Voice: musical, rhythmic, memorable.`,
+- Voice: musical, rhythmic, memorable.
+- After creating lyrics, share a contribution summary so Scene Painter or Storyteller can react.
+- Request another persona when you want visual interpretation or narrative continuation.`,
   },
 
   analyst: {
@@ -112,7 +122,8 @@ You specialize in narrative beats, character tension, and scene transitions.
 - Edge creation: labels like "reveals", "foreshadows", "conflicts with", "resolves into".
 - Node variety: text_block for scenes, sticky_note for beats, ai_response for narrator lens.
 - Color usage: map colors to mood shifts across the story arc.
-- Voice: clear, emotive, scene-driven.`,
+- Voice: clear, emotive, scene-driven.
+- React to contributions from Songwriter/Scene Painter with connective narrative bridges.`,
   },
 
   'canvas-agent': {

--- a/apps/api/src/agent/agent-runner.service.integration.spec.ts
+++ b/apps/api/src/agent/agent-runner.service.integration.spec.ts
@@ -17,11 +17,17 @@ describe('AgentRunnerService integration', () => {
     broadcastNodeDeleted: jest.fn(),
     broadcastEdgeCreated: jest.fn(),
     broadcastEdgeDeleted: jest.fn(),
+    broadcastAgentCollaboration: jest.fn(),
   };
   const sessions = {
     create: jest.fn(),
     updateStatus: jest.fn(),
     appendToolCall: jest.fn(),
+  };
+  const sharedContext = {
+    getRecentEntries: jest.fn().mockResolvedValue([]),
+    getOpenRequests: jest.fn().mockResolvedValue([]),
+    addEntry: jest.fn(),
   };
 
   let service: AgentRunnerService;
@@ -40,6 +46,7 @@ describe('AgentRunnerService integration', () => {
       canvasService as any,
       broadcast as any,
       sessions as any,
+      sharedContext as any,
     );
 
     (service as any).runAgentLoop = jest.fn().mockResolvedValue(undefined);

--- a/apps/api/src/agent/agent-tools.ts
+++ b/apps/api/src/agent/agent-tools.ts
@@ -113,6 +113,70 @@ export const CANVAS_TOOLS: ToolDefinition[] = [
       },
     },
   },
+  {
+    name: 'share_creative_context',
+    description:
+      'Share a theme, intention, contribution summary, or request with other agents on this canvas.',
+    parameters: {
+      type: 'object',
+      required: ['entryType', 'content'],
+      properties: {
+        entryType: {
+          type: 'string',
+          enum: ['theme', 'intention', 'contribution', 'request', 'reaction'],
+          description: 'Type of shared context entry',
+        },
+        content: {
+          type: 'object',
+          description:
+            'Structured entry content. For request entries include targetPersona and ask. For reactions include toEntryId and response.',
+        },
+      },
+    },
+  },
+  {
+    name: 'read_shared_context',
+    description: 'Read recent creative context from other agents on this canvas.',
+    parameters: {
+      type: 'object',
+      properties: {
+        entryType: {
+          type: 'string',
+          enum: ['theme', 'intention', 'contribution', 'request', 'reaction'],
+          description: 'Optional entry type filter',
+        },
+        limit: {
+          type: 'number',
+          description: 'Max number of entries to return (default 20, max 50)',
+        },
+      },
+    },
+  },
+  {
+    name: 'request_agent',
+    description:
+      'Request another persona to respond to your work. Creates a shared request and triggers that persona when capacity allows.',
+    parameters: {
+      type: 'object',
+      required: ['targetPersona', 'prompt'],
+      properties: {
+        targetPersona: {
+          type: 'string',
+          enum: ['brainstormer', 'architect', 'coder', 'analyst', 'canvas-agent'],
+          description: 'Persona key to invoke',
+        },
+        prompt: {
+          type: 'string',
+          description: 'Instruction for the requested persona',
+        },
+        refNodeIds: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Optional node IDs that should be used as references',
+        },
+      },
+    },
+  },
 ];
 
 /**

--- a/apps/api/src/agent/agent.module.ts
+++ b/apps/api/src/agent/agent.module.ts
@@ -8,11 +8,12 @@ import { AgentRunnerController } from './agent-runner.controller';
 import { AgentRunnerService } from './agent-runner.service';
 import { AgentSessionRepository } from './agent-session.repository';
 import { AgentSchedulerService } from './agent-scheduler.service';
+import { SharedContextRepository } from './shared-context.repository';
 
 @Module({
   imports: [CanvasModule, NodesModule, EdgesModule, CollaborationModule, AuthModule],
   controllers: [AgentRunnerController],
-  providers: [AgentRunnerService, AgentSessionRepository, AgentSchedulerService],
+  providers: [AgentRunnerService, AgentSessionRepository, SharedContextRepository, AgentSchedulerService],
   exports: [AgentRunnerService],
 })
 export class AgentModule {}

--- a/apps/api/src/agent/shared-context.repository.ts
+++ b/apps/api/src/agent/shared-context.repository.ts
@@ -1,0 +1,121 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { Pool } from 'pg';
+import { PG_POOL } from '../database/database.provider';
+import type { SharedContextEntry, SharedContextEntryType } from '@mindscape/shared';
+
+interface SharedContextRow {
+  id: string;
+  canvas_id: string;
+  session_id: string | null;
+  agent_name: string;
+  entry_type: SharedContextEntryType;
+  content: Record<string, unknown>;
+  expires_at: string | null;
+  created_at: string;
+}
+
+@Injectable()
+export class SharedContextRepository {
+  constructor(@Inject(PG_POOL) private readonly pg: Pool) {}
+
+  async addEntry(
+    canvasId: string,
+    sessionId: string | null,
+    agentName: string,
+    entryType: SharedContextEntryType,
+    content: Record<string, unknown>,
+  ): Promise<SharedContextEntry> {
+    const { rows } = await this.pg.query<SharedContextRow>(
+      `INSERT INTO canvas_shared_context (canvas_id, session_id, agent_name, entry_type, content)
+       VALUES ($1, $2, $3, $4, $5::jsonb)
+       RETURNING *`,
+      [canvasId, sessionId, agentName, entryType, JSON.stringify(content)],
+    );
+
+    return this.toEntry(rows[0]);
+  }
+
+  async getRecentEntries(
+    canvasId: string,
+    options?: {
+      entryType?: SharedContextEntryType;
+      limit?: number;
+      excludeSessionId?: string;
+    },
+  ): Promise<SharedContextEntry[]> {
+    await this.pruneExpired(canvasId);
+
+    const where: string[] = ['canvas_id = $1'];
+    const params: unknown[] = [canvasId];
+
+    if (options?.entryType) {
+      params.push(options.entryType);
+      where.push(`entry_type = $${params.length}`);
+    }
+
+    if (options?.excludeSessionId) {
+      params.push(options.excludeSessionId);
+      where.push(`(session_id IS NULL OR session_id <> $${params.length})`);
+    }
+
+    const limit = Math.max(1, Math.min(options?.limit ?? 20, 100));
+    params.push(limit);
+
+    const { rows } = await this.pg.query<SharedContextRow>(
+      `SELECT *
+       FROM canvas_shared_context
+       WHERE ${where.join(' AND ')}
+       ORDER BY created_at DESC
+       LIMIT $${params.length}`,
+      params,
+    );
+
+    return rows.map((row) => this.toEntry(row));
+  }
+
+  async getActiveThemes(canvasId: string): Promise<SharedContextEntry[]> {
+    return this.getRecentEntries(canvasId, { entryType: 'theme', limit: 20 });
+  }
+
+  async getOpenRequests(
+    canvasId: string,
+    targetPersona?: string,
+    excludeSessionId?: string,
+  ): Promise<SharedContextEntry[]> {
+    const requests = await this.getRecentEntries(canvasId, {
+      entryType: 'request',
+      limit: 20,
+      excludeSessionId,
+    });
+    if (!targetPersona) return requests;
+
+    return requests.filter((entry) => {
+      const target = entry.content.targetPersona;
+      return typeof target !== 'string' || target === targetPersona;
+    });
+  }
+
+  async pruneExpired(canvasId: string): Promise<number> {
+    const { rowCount } = await this.pg.query(
+      `DELETE FROM canvas_shared_context
+       WHERE canvas_id = $1
+         AND expires_at IS NOT NULL
+         AND expires_at < NOW()`,
+      [canvasId],
+    );
+    return rowCount ?? 0;
+  }
+
+  private toEntry(row: SharedContextRow): SharedContextEntry {
+    return {
+      id: row.id,
+      canvasId: row.canvas_id,
+      sessionId: row.session_id,
+      agentName: row.agent_name,
+      entryType: row.entry_type,
+      content: row.content,
+      expiresAt: row.expires_at,
+      createdAt: row.created_at,
+    };
+  }
+}

--- a/apps/api/src/collaboration/agent-broadcast.service.ts
+++ b/apps/api/src/collaboration/agent-broadcast.service.ts
@@ -6,6 +6,7 @@ import type {
   NodePayload,
   EdgePayload,
   AgentStatus,
+  CollaborationEventType,
 } from '@mindscape/shared';
 
 type TypedServer = Server<ClientToServerEvents, ServerToClientEvents>;
@@ -78,6 +79,19 @@ export class AgentBroadcastService {
 
   broadcastAgentError(canvasId: string, sessionId: string, error: string) {
     this.emit(canvasId, 'agent:error', { sessionId, error });
+  }
+
+  broadcastAgentCollaboration(
+    canvasId: string,
+    sessionId: string,
+    payload: {
+      type: CollaborationEventType;
+      fromAgent: string;
+      toAgent?: string;
+      summary: string;
+    },
+  ) {
+    this.emit(canvasId, 'agent:collaboration', { sessionId, ...payload });
   }
 
   /* ──────────────────── internal helper ──────────────────── */

--- a/apps/api/src/database/migrations/008_create_canvas_shared_context.sql
+++ b/apps/api/src/database/migrations/008_create_canvas_shared_context.sql
@@ -1,0 +1,19 @@
+CREATE TABLE canvas_shared_context (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  canvas_id UUID NOT NULL REFERENCES canvases(id) ON DELETE CASCADE,
+  session_id UUID REFERENCES agent_sessions(id) ON DELETE SET NULL,
+  agent_name TEXT NOT NULL,
+  entry_type TEXT NOT NULL CHECK (entry_type IN (
+    'theme',
+    'intention',
+    'contribution',
+    'request',
+    'reaction'
+  )),
+  content JSONB NOT NULL DEFAULT '{}',
+  expires_at TIMESTAMPTZ DEFAULT (NOW() + INTERVAL '1 hour'),
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX idx_shared_context_canvas ON canvas_shared_context(canvas_id);
+CREATE INDEX idx_shared_context_type ON canvas_shared_context(canvas_id, entry_type);

--- a/apps/web/src/components/canvas/ActivityFeed.tsx
+++ b/apps/web/src/components/canvas/ActivityFeed.tsx
@@ -25,6 +25,17 @@ function formatEntry(entry: AgentActivity): string {
     }
     case 'error':
       return `Error: ${String(entry.data)}`;
+    case 'collaboration': {
+      const body = entry.data as { fromAgent?: string; toAgent?: string; summary?: string; type?: string };
+      if (body.type === 'agent_request') {
+        const target = body.toAgent ? ` -> ${body.toAgent}` : '';
+        return `${body.fromAgent ?? 'Agent'} requested${target}: ${body.summary ?? 'collaboration request'}`;
+      }
+      if (body.type === 'agent_reaction') {
+        return `${body.fromAgent ?? 'Agent'} reacted: ${body.summary ?? 'reaction shared'}`;
+      }
+      return `${body.fromAgent ?? 'Agent'} shared context: ${body.summary ?? 'update'}`;
+    }
     default:
       return 'Event';
   }

--- a/apps/web/src/hooks/use-canvas-socket.ts
+++ b/apps/web/src/hooks/use-canvas-socket.ts
@@ -95,6 +95,9 @@ export function useCanvasSocket(canvasId: string) {
     socket.on('agent:error', (data) =>
       pushAgentActivity({ sessionId: data.sessionId, type: 'error', data: data.error, timestamp: Date.now() }),
     );
+    socket.on('agent:collaboration', (data) =>
+      pushAgentActivity({ sessionId: data.sessionId, type: 'collaboration', data, timestamp: Date.now() }),
+    );
     socket.on('agent:cursor', (data) =>
       upsertAgentCursor({ sessionId: data.sessionId, x: data.x, y: data.y, timestamp: Date.now() }),
     );

--- a/apps/web/src/stores/canvas-store.ts
+++ b/apps/web/src/stores/canvas-store.ts
@@ -4,7 +4,7 @@ import type { NodePayload, EdgePayload, PresenceUser, AgentStatus } from '@minds
 /* ─── Agent activity entry shown in the activity feed ─── */
 export interface AgentActivity {
   sessionId: string;
-  type: 'status' | 'thought' | 'tool-call' | 'error';
+  type: 'status' | 'thought' | 'tool-call' | 'error' | 'collaboration';
   data: unknown;
   timestamp: number;
 }

--- a/packages/shared/src/agent-types.ts
+++ b/packages/shared/src/agent-types.ts
@@ -23,11 +23,27 @@ export interface AgentInvokePayload {
   prompt: string;
   model?: string;
   agentType?: string;
+  depth?: number;
   context?: {
     selectedNodeIds?: string[];
     viewport?: { x: number; y: number; width: number; height: number; zoom: number };
   };
 }
+
+export type SharedContextEntryType = 'theme' | 'intention' | 'contribution' | 'request' | 'reaction';
+
+export interface SharedContextEntry {
+  id: string;
+  canvasId: string;
+  sessionId: string | null;
+  agentName: string;
+  entryType: SharedContextEntryType;
+  content: Record<string, unknown>;
+  expiresAt: string | null;
+  createdAt: string;
+}
+
+export type CollaborationEventType = 'shared_context' | 'agent_request' | 'agent_reaction';
 
 export interface PresenceUser {
   id: string;

--- a/packages/shared/src/ws-events.ts
+++ b/packages/shared/src/ws-events.ts
@@ -1,5 +1,5 @@
 import type { NodePayload, EdgePayload } from './canvas-types';
-import type { AgentStatus, PresenceUser } from './agent-types';
+import type { AgentStatus, CollaborationEventType, PresenceUser } from './agent-types';
 
 /**
  * Events the CLIENT can send to the server.
@@ -45,4 +45,11 @@ export interface ServerToClientEvents {
   'agent:tool-call': (data: { sessionId: string; tool: string; args: unknown; result: unknown }) => void;
   'agent:cursor': (data: { sessionId: string; x: number; y: number }) => void;
   'agent:error': (data: { sessionId: string; error: string }) => void;
+  'agent:collaboration': (data: {
+    sessionId: string;
+    type: CollaborationEventType;
+    fromAgent: string;
+    toAgent?: string;
+    summary: string;
+  }) => void;
 }


### PR DESCRIPTION
## Summary
- add `canvas_shared_context` migration and repository for collaboration entries
- add collaboration tools (`share_creative_context`, `read_shared_context`, `request_agent`) and runner handlers with depth/rate safeguards
- inject shared context + directed requests into agent prompts, update persona collaboration instructions, and make scheduler request-aware
- add `agent:collaboration` websocket event and surface it in the web activity feed

## Validation
- npm run lint --workspace=@mindscape/shared
- npm run test --workspace=@mindscape/api -- agent-runner.service.integration.spec.ts
- npm run build --workspace=@mindscape/api
- npm run build --workspace=@mindscape/web

Closes #44
